### PR TITLE
END_OF_RESULT_SET fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,3 +273,16 @@ Future<String> json = fieldOps.get(read, new AsyncHandler<FieldObject, String>()
 
 System.out.println(json.get());
 ```
+
+### Read Conversions
+
+``` java
+ObjectOperationsAsync<ConversionObject> conversionOps =
+        client.transportAsync(ConversionObject.class);
+ConversionReadRequest conversions = new ConversionReadRequest();
+for (ConversionObject conversion : conversionOps.readAll(conversions)) {
+    System.out.println(String.format("Conversion id: %s (email: %s) "
+            + "- item = %s", conversion.getId(), conversion.getEmail(),
+            conversion.getItem()));
+}
+```

--- a/app/src/main/java/com/bronto/api/app/App.java
+++ b/app/src/main/java/com/bronto/api/app/App.java
@@ -107,21 +107,6 @@ public class App {
         			headerFooter.isIsHeader()));
         }
 
-		/*
-		 * The conversion calls are slow, so it's recommended that the
-		 * conversion checks be left commented-out by default unless you're
-		 * actively testing conversions.
-		 */
-		// ObjectOperationsAsync<ConversionObject> conversionOps =
-		// client.transportAsync(ConversionObject.class);
-		// ConversionReadRequest conversions = new ConversionReadRequest();
-		// for (ConversionObject conversion :
-		// conversionOps.readAll(conversions)) {
-		// System.out.println(String.format("Conversion id: %s (email: %s) "
-		// + "- item = %s", conversion.getId(), conversion.getEmail(),
-		// conversion.getItem()));
-		// }
-
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
         if (reader.readLine() != null) {
             client.shutdown();

--- a/sdk/src/main/java/com/bronto/api/request/BrontoReadPager.java
+++ b/sdk/src/main/java/com/bronto/api/request/BrontoReadPager.java
@@ -1,10 +1,10 @@
 package com.bronto.api.request;
 
 import com.bronto.api.BrontoApi;
+import com.bronto.api.BrontoClientException;
 
 import java.util.Collections;
 import java.util.concurrent.Future;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -27,19 +27,16 @@ public class BrontoReadPager<T> implements Iterator<T> {
     private Iterator<T> getCurrentObjects() {
 		try {
 			return ((List<T>) client.invoke(read)).iterator();
-		} catch (Exception e) {
+		} catch (BrontoClientException brontoException) {
 			/*
-			 * The "end of result set" error should be handled cleanly (by
-			 * returning an empty iterator), but everything else should still be
-			 * handled by the existing error handling logic. So far this has
-			 * only affected conversion calls, but there's no telling what other
-			 * calls (if any). If there are other calls impacted, this will fix
-			 * them as well.
+			 * Error code 116 is an end of result error. Since all the data's
+			 * been read, return an empty list. All other exceptions should be
+			 * handled by the existing exception-handling logic.
 			 */
-			if (e.getMessage().contains("End of result set")) {
-				return new ArrayList<T>().iterator();
+			if (brontoException.getCode() == 116) {
+				return Collections.emptyListIterator();
 			} else {
-				throw e;
+				throw brontoException;
 			}
 		}
     }


### PR DESCRIPTION
Fix for JAVA-10, as well as some test code for reading conversions in App.java in case we ever need to test something with conversions in the future. I left that code commented out since the conversions call seems to be slower than the other Bronto calls. 
