### PR TITLE
JAVA-21 Fixed an issue parsing error codes from SOAPFaultExceptions.

### DIFF
--- a/app/src/main/java/com/bronto/api/app/App.java
+++ b/app/src/main/java/com/bronto/api/app/App.java
@@ -1,17 +1,38 @@
 package com.bronto.api.app;
 
-import com.bronto.api.*;
-import com.bronto.api.model.*;
-import com.bronto.api.request.*;
-import com.bronto.api.operation.*;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPFactory;
+import javax.xml.soap.SOAPFault;
+import javax.xml.ws.soap.SOAPFaultException;
+
+import com.bronto.api.BrontoApiAsync;
+import com.bronto.api.BrontoClientAsync;
+import com.bronto.api.BrontoClientException;
+import com.bronto.api.ObjectOperationsAsync;
+import com.bronto.api.model.ContactObject;
+import com.bronto.api.model.ContactStatus;
+import com.bronto.api.model.DeliveryObject;
+import com.bronto.api.model.DeliveryRecipientObject;
+import com.bronto.api.model.DeliveryStatus;
+import com.bronto.api.model.DeliveryType;
+import com.bronto.api.model.FieldObject;
+import com.bronto.api.model.FilterOperator;
+import com.bronto.api.model.HeaderFooterObject;
+import com.bronto.api.model.MailListObject;
+import com.bronto.api.operation.ContactOperationsAsync;
+import com.bronto.api.operation.MailListOperationsAsync;
+import com.bronto.api.request.AsyncReadPager;
+import com.bronto.api.request.BrontoReadRequest;
+import com.bronto.api.request.ContactReadRequest;
+import com.bronto.api.request.DeliveryReadRequest;
+import com.bronto.api.request.FieldReadRequest;
+import com.bronto.api.request.HeaderFooterReadRequest;
+import com.bronto.api.request.MailListReadRequest;
 
 public class App {
 
@@ -96,6 +117,12 @@ public class App {
             }
         }
 
+        SOAPFault fault = SOAPFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL).createFault();
+        fault.setFaultString("Client received SOAP Fault from server: 246: This is my message");
+        SOAPFaultException exception = new SOAPFaultException(fault);
+        BrontoClientException bce = new BrontoClientException(exception);
+        System.out.println("BrontoClientException code is " + bce.getCode());
+        
         HeaderFooterReadRequest headerFooters =
         		new HeaderFooterReadRequest().withIncludeContent(true);
         for (HeaderFooterObject headerFooter :
@@ -111,6 +138,5 @@ public class App {
         if (reader.readLine() != null) {
             client.shutdown();
         }
-
     }
 }

--- a/sdk/src/main/java/com/bronto/api/BrontoClientException.java
+++ b/sdk/src/main/java/com/bronto/api/BrontoClientException.java
@@ -52,8 +52,7 @@ public class BrontoClientException extends RuntimeException {
         if (getCause() instanceof ApiException_Exception) {
             this.code = ((ApiException_Exception) getCause()).getFaultInfo().getErrorCode();
 		} else if (getCause() instanceof SOAPFaultException) {
-			this.code =
-			        parseCodeFromMessage(((SOAPFaultException) getCause()).getMessage());
+			this.code = parseCodeFromMessage(((SOAPFaultException) getCause()).getMessage());
         }
         for (Recoverable recover : Recoverable.values()) {
             if (recover.isRecoverable(getCause().getMessage())) {
@@ -95,7 +94,7 @@ public class BrontoClientException extends RuntimeException {
 
 	private int parseCodeFromMessage(String message) {
 		if (message.contains(":")) {
-			String codeString = message.split(":")[0];
+			String codeString = message.split(":")[1].trim();
 			try {
 				return Integer.parseInt(codeString);
 			} catch (NumberFormatException nfe) {


### PR DESCRIPTION
The actual error code in the SOAPFaultException is in token 1 of the message (when split on ":"), not 0. 