### PR TITLE
JAVA-22: Re-generate WSDL and add pageSize support

### DIFF
--- a/client/src/main/java/com/bronto/api/model/AccountFilter.java
+++ b/client/src/main/java/com/bronto/api/model/AccountFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -38,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class AccountFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/ActivityFilter.java
+++ b/client/src/main/java/com/bronto/api/model/ActivityFilter.java
@@ -47,6 +47,7 @@ public class ActivityFilter {
     protected Integer size;
     @XmlElement(nillable = true)
     protected List<String> types;
+    @XmlSchemaType(name = "string")
     protected ReadDirection readDirection;
 
     /**

--- a/client/src/main/java/com/bronto/api/model/ApiException_Exception.java
+++ b/client/src/main/java/com/bronto/api/model/ApiException_Exception.java
@@ -15,7 +15,9 @@ public class ApiException_Exception
     extends Exception
 {
 
-    /**
+	private static final long serialVersionUID = 2921604280815602362L;
+	
+	/**
      * Java type that goes as soapenv:Fault detail element.
      * 
      */

--- a/client/src/main/java/com/bronto/api/model/ApiTokenFilter.java
+++ b/client/src/main/java/com/bronto/api/model/ApiTokenFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -40,6 +41,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class ApiTokenFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/ContactFilter.java
+++ b/client/src/main/java/com/bronto/api/model/ContactFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -58,6 +59,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class ContactFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/ContentTagFilter.java
+++ b/client/src/main/java/com/bronto/api/model/ContentTagFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -38,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class ContentTagFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/DateValue.java
+++ b/client/src/main/java/com/bronto/api/model/DateValue.java
@@ -35,6 +35,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 })
 public class DateValue {
 
+    @XmlSchemaType(name = "string")
     protected FilterOperator operator;
     @XmlSchemaType(name = "dateTime")
     protected XMLGregorianCalendar value;

--- a/client/src/main/java/com/bronto/api/model/DeliveryFilter.java
+++ b/client/src/main/java/com/bronto/api/model/DeliveryFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -44,6 +45,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class DeliveryFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/DeliveryGroupFilter.java
+++ b/client/src/main/java/com/bronto/api/model/DeliveryGroupFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -46,6 +47,7 @@ public class DeliveryGroupFilter {
 
     @XmlElement(nillable = true)
     protected List<String> deliveryGroupId;
+    @XmlSchemaType(name = "string")
     protected MemberType listByType;
     @XmlElement(nillable = true)
     protected List<String> automatorId;

--- a/client/src/main/java/com/bronto/api/model/DeliveryObject.java
+++ b/client/src/main/java/com/bronto/api/model/DeliveryObject.java
@@ -39,6 +39,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
  *         &lt;element name="content" type="{http://api.bronto.com/v4}messageContentObject" maxOccurs="unbounded" minOccurs="0"/>
  *         &lt;element name="recipients" type="{http://api.bronto.com/v4}deliveryRecipientObject" maxOccurs="unbounded" minOccurs="0"/>
  *         &lt;element name="fields" type="{http://api.bronto.com/v4}messageFieldObject" maxOccurs="unbounded" minOccurs="0"/>
+ *         &lt;element name="products" type="{http://api.bronto.com/v4}deliveryProductObject" maxOccurs="unbounded" minOccurs="0"/>
  *         &lt;element name="remail" type="{http://api.bronto.com/v4}remailObject" minOccurs="0"/>
  *         &lt;element name="numSends" type="{http://www.w3.org/2001/XMLSchema}long" minOccurs="0"/>
  *         &lt;element name="numDeliveries" type="{http://www.w3.org/2001/XMLSchema}long" minOccurs="0"/>
@@ -118,6 +119,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
     "content",
     "recipients",
     "fields",
+    "products",
     "remail",
     "numSends",
     "numDeliveries",
@@ -194,6 +196,8 @@ public class DeliveryObject {
     protected List<DeliveryRecipientObject> recipients;
     @XmlElement(nillable = true)
     protected List<MessageFieldObject> fields;
+    @XmlElement(nillable = true)
+    protected List<DeliveryProductObject> products;
     protected RemailObject remail;
     protected Long numSends;
     protected Long numDeliveries;
@@ -668,6 +672,35 @@ public class DeliveryObject {
             fields = new ArrayList<MessageFieldObject>();
         }
         return this.fields;
+    }
+
+    /**
+     * Gets the value of the products property.
+     * 
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the products property.
+     * 
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getProducts().add(newItem);
+     * </pre>
+     * 
+     * 
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link DeliveryProductObject }
+     * 
+     * 
+     */
+    public List<DeliveryProductObject> getProducts() {
+        if (products == null) {
+            products = new ArrayList<DeliveryProductObject>();
+        }
+        return this.products;
     }
 
     /**

--- a/client/src/main/java/com/bronto/api/model/DeliveryProductObject.java
+++ b/client/src/main/java/com/bronto/api/model/DeliveryProductObject.java
@@ -1,0 +1,87 @@
+
+package com.bronto.api.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for deliveryProductObject complex type.
+ * 
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ * 
+ * <pre>
+ * &lt;complexType name="deliveryProductObject">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="placeholder" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *         &lt;element name="productId" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ * 
+ * 
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "deliveryProductObject", propOrder = {
+    "placeholder",
+    "productId"
+})
+public class DeliveryProductObject {
+
+    protected String placeholder;
+    protected String productId;
+
+    /**
+     * Gets the value of the placeholder property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    /**
+     * Sets the value of the placeholder property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setPlaceholder(String value) {
+        this.placeholder = value;
+    }
+
+    /**
+     * Gets the value of the productId property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getProductId() {
+        return productId;
+    }
+
+    /**
+     * Sets the value of the productId property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setProductId(String value) {
+        this.productId = value;
+    }
+
+}

--- a/client/src/main/java/com/bronto/api/model/DeliveryRecipientFilter.java
+++ b/client/src/main/java/com/bronto/api/model/DeliveryRecipientFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -42,6 +43,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class DeliveryRecipientFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     protected String deliveryId;
     @XmlElement(nillable = true)

--- a/client/src/main/java/com/bronto/api/model/FieldsFilter.java
+++ b/client/src/main/java/com/bronto/api/model/FieldsFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -38,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class FieldsFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/HeaderFooterFilter.java
+++ b/client/src/main/java/com/bronto/api/model/HeaderFooterFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -40,6 +41,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class HeaderFooterFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/LoginFilter.java
+++ b/client/src/main/java/com/bronto/api/model/LoginFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -36,6 +37,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class LoginFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<StringValue> username;

--- a/client/src/main/java/com/bronto/api/model/MailListFilter.java
+++ b/client/src/main/java/com/bronto/api/model/MailListFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -38,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class MailListFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/MessageFilter.java
+++ b/client/src/main/java/com/bronto/api/model/MessageFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -42,6 +43,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class MessageFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/MessageFolderFilter.java
+++ b/client/src/main/java/com/bronto/api/model/MessageFolderFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -40,6 +41,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class MessageFolderFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/MessageRuleFilter.java
+++ b/client/src/main/java/com/bronto/api/model/MessageRuleFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -40,6 +41,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class MessageRuleFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/ObjectFactory.java
+++ b/client/src/main/java/com/bronto/api/model/ObjectFactory.java
@@ -24,1432 +24,200 @@ import javax.xml.namespace.QName;
 @XmlRegistry
 public class ObjectFactory {
 
-    private final static QName _AddConversionResponse_QNAME = new QName("http://api.bronto.com/v4", "addConversionResponse");
-    private final static QName _UpdateContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateContentTagsResponse");
-    private final static QName _DeleteApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteApiTokensResponse");
-    private final static QName _ReadContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "readContactsResponse");
-    private final static QName _AddApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "addApiTokensResponse");
-    private final static QName _DeleteDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteDeliveriesResponse");
-    private final static QName _ReadConversionsResponse_QNAME = new QName("http://api.bronto.com/v4", "readConversionsResponse");
-    private final static QName _ReadMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "readMessageFoldersResponse");
-    private final static QName _AddSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "addSMSKeywords");
-    private final static QName _ReadFields_QNAME = new QName("http://api.bronto.com/v4", "readFields");
-    private final static QName _ReadRecentOutboundActivitiesResponse_QNAME = new QName("http://api.bronto.com/v4", "readRecentOutboundActivitiesResponse");
-    private final static QName _ReadDeliveryRecipientsResponse_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryRecipientsResponse");
-    private final static QName _ReadSegments_QNAME = new QName("http://api.bronto.com/v4", "readSegments");
-    private final static QName _UpdateMessageFolders_QNAME = new QName("http://api.bronto.com/v4", "updateMessageFolders");
-    private final static QName _AddToSMSKeywordResponse_QNAME = new QName("http://api.bronto.com/v4", "addToSMSKeywordResponse");
-    private final static QName _ReadActivities_QNAME = new QName("http://api.bronto.com/v4", "readActivities");
-    private final static QName _ReadRecentOutboundActivities_QNAME = new QName("http://api.bronto.com/v4", "readRecentOutboundActivities");
-    private final static QName _UpdateMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "updateMessageFoldersResponse");
-    private final static QName _AddOrUpdateOrders_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateOrders");
-    private final static QName _ReadConversions_QNAME = new QName("http://api.bronto.com/v4", "readConversions");
-    private final static QName _AddDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "addDeliveryGroupResponse");
-    private final static QName _ClearLists_QNAME = new QName("http://api.bronto.com/v4", "clearLists");
-    private final static QName _AddLogins_QNAME = new QName("http://api.bronto.com/v4", "addLogins");
-    private final static QName _Login_QNAME = new QName("http://api.bronto.com/v4", "login");
-    private final static QName _DeleteDeliveries_QNAME = new QName("http://api.bronto.com/v4", "deleteDeliveries");
-    private final static QName _AddMessages_QNAME = new QName("http://api.bronto.com/v4", "addMessages");
-    private final static QName _ReadAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "readAccountsResponse");
-    private final static QName _UpdateDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveryGroup");
-    private final static QName _ReadApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "readApiTokensResponse");
-    private final static QName _UpdateLists_QNAME = new QName("http://api.bronto.com/v4", "updateLists");
-    private final static QName _ReadSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "readSMSDeliveries");
-    private final static QName _DeleteListsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteListsResponse");
-    private final static QName _UpdateWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateWorkflowsResponse");
-    private final static QName _UpdateSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "updateSMSKeywords");
-    private final static QName _ReadHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "readHeaderFootersResponse");
-    private final static QName _ReadDeliveryRecipients_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryRecipients");
-    private final static QName _DeleteDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteDeliveryGroupResponse");
-    private final static QName _AddSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "addSMSMessagesResponse");
-    private final static QName _AddContactEvent_QNAME = new QName("http://api.bronto.com/v4", "addContactEvent");
-    private final static QName _ReadSMSMessages_QNAME = new QName("http://api.bronto.com/v4", "readSMSMessages");
-    private final static QName _DeleteMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageRulesResponse");
-    private final static QName _DeleteLists_QNAME = new QName("http://api.bronto.com/v4", "deleteLists");
-    private final static QName _AddHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "addHeaderFooters");
-    private final static QName _AddMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "addMessageRulesResponse");
-    private final static QName _DeleteApiTokens_QNAME = new QName("http://api.bronto.com/v4", "deleteApiTokens");
-    private final static QName _AddUpdateOrderResponse_QNAME = new QName("http://api.bronto.com/v4", "addUpdateOrderResponse");
-    private final static QName _DeleteSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSMessagesResponse");
-    private final static QName _DeleteSMSDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSDeliveriesResponse");
-    private final static QName _UpdateHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "updateHeaderFootersResponse");
-    private final static QName _ReadMessages_QNAME = new QName("http://api.bronto.com/v4", "readMessages");
-    private final static QName _ReadMessageRules_QNAME = new QName("http://api.bronto.com/v4", "readMessageRules");
-    private final static QName _ReadWebforms_QNAME = new QName("http://api.bronto.com/v4", "readWebforms");
-    private final static QName _AddContactsToWorkflow_QNAME = new QName("http://api.bronto.com/v4", "addContactsToWorkflow");
-    private final static QName _ReadContentTags_QNAME = new QName("http://api.bronto.com/v4", "readContentTags");
-    private final static QName _DeleteOrders_QNAME = new QName("http://api.bronto.com/v4", "deleteOrders");
-    private final static QName _AddHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "addHeaderFootersResponse");
-    private final static QName _DeleteWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteWorkflowsResponse");
-    private final static QName _AddOrUpdateContacts_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateContacts");
-    private final static QName _DeleteMessages_QNAME = new QName("http://api.bronto.com/v4", "deleteMessages");
-    private final static QName _AddMessageRules_QNAME = new QName("http://api.bronto.com/v4", "addMessageRules");
-    private final static QName _AddToListResponse_QNAME = new QName("http://api.bronto.com/v4", "addToListResponse");
     private final static QName _ClearListsResponse_QNAME = new QName("http://api.bronto.com/v4", "clearListsResponse");
-    private final static QName _AddListsResponse_QNAME = new QName("http://api.bronto.com/v4", "addListsResponse");
-    private final static QName _ReadLists_QNAME = new QName("http://api.bronto.com/v4", "readLists");
-    private final static QName _ReadMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "readMessageRulesResponse");
-    private final static QName _AddFieldsResponse_QNAME = new QName("http://api.bronto.com/v4", "addFieldsResponse");
-    private final static QName _ReadLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "readLoginsResponse");
-    private final static QName _AddAccounts_QNAME = new QName("http://api.bronto.com/v4", "addAccounts");
-    private final static QName _ReadSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "readSMSKeywords");
-    private final static QName _RemoveFromSMSKeywordResponse_QNAME = new QName("http://api.bronto.com/v4", "removeFromSMSKeywordResponse");
-    private final static QName _UpdateFields_QNAME = new QName("http://api.bronto.com/v4", "updateFields");
-    private final static QName _AddMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "addMessageFoldersResponse");
-    private final static QName _ReadSMSKeywordsResponse_QNAME = new QName("http://api.bronto.com/v4", "readSMSKeywordsResponse");
-    private final static QName _UpdateListsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateListsResponse");
-    private final static QName _ReadAccounts_QNAME = new QName("http://api.bronto.com/v4", "readAccounts");
-    private final static QName _AddContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "addContentTagsResponse");
-    private final static QName _ReadWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "readWorkflowsResponse");
-    private final static QName _DeleteSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSKeywords");
-    private final static QName _DeleteMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageFoldersResponse");
-    private final static QName _AddOrUpdateDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateDeliveryGroupResponse");
-    private final static QName _DeleteContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteContactsResponse");
-    private final static QName _DeleteAccounts_QNAME = new QName("http://api.bronto.com/v4", "deleteAccounts");
-    private final static QName _RemoveFromList_QNAME = new QName("http://api.bronto.com/v4", "removeFromList");
-    private final static QName _RemoveFromListResponse_QNAME = new QName("http://api.bronto.com/v4", "removeFromListResponse");
-    private final static QName _AddMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "addMessagesResponse");
-    private final static QName _ReadContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "readContentTagsResponse");
-    private final static QName _UpdateLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateLoginsResponse");
-    private final static QName _AddOrUpdateContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateContactsResponse");
-    private final static QName _AddDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "addDeliveriesResponse");
-    private final static QName _AddDeliveries_QNAME = new QName("http://api.bronto.com/v4", "addDeliveries");
-    private final static QName _AddContentTags_QNAME = new QName("http://api.bronto.com/v4", "addContentTags");
-    private final static QName _ReadContacts_QNAME = new QName("http://api.bronto.com/v4", "readContacts");
-    private final static QName _AddContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "addContactsResponse");
-    private final static QName _DeleteMessageFolders_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageFolders");
     private final static QName _UpdateContacts_QNAME = new QName("http://api.bronto.com/v4", "updateContacts");
-    private final static QName _ReadApiTokens_QNAME = new QName("http://api.bronto.com/v4", "readApiTokens");
-    private final static QName _UpdateMessages_QNAME = new QName("http://api.bronto.com/v4", "updateMessages");
-    private final static QName _DeleteMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteMessagesResponse");
-    private final static QName _ReadBounces_QNAME = new QName("http://api.bronto.com/v4", "readBounces");
-    private final static QName _ReadListsResponse_QNAME = new QName("http://api.bronto.com/v4", "readListsResponse");
-    private final static QName _UpdateSMSMessages_QNAME = new QName("http://api.bronto.com/v4", "updateSMSMessages");
-    private final static QName _ReadDeliveryGroupsResponse_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryGroupsResponse");
-    private final static QName _AddToDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "addToDeliveryGroupResponse");
-    private final static QName _UpdateDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveryGroupResponse");
-    private final static QName _UpdateFieldsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateFieldsResponse");
-    private final static QName _UpdateDeliveries_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveries");
-    private final static QName _AddToSMSKeyword_QNAME = new QName("http://api.bronto.com/v4", "addToSMSKeyword");
-    private final static QName _AddSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "addSMSDeliveries");
-    private final static QName _UpdateSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateSMSMessagesResponse");
-    private final static QName _AddContacts_QNAME = new QName("http://api.bronto.com/v4", "addContacts");
-    private final static QName _AddLists_QNAME = new QName("http://api.bronto.com/v4", "addLists");
-    private final static QName _ReadSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "readSMSMessagesResponse");
+    private final static QName _ReadMessages_QNAME = new QName("http://api.bronto.com/v4", "readMessages");
+    private final static QName _AddOrUpdateContacts_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateContacts");
     private final static QName _DeleteSMSMessages_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSMessages");
-    private final static QName _UpdateApiTokens_QNAME = new QName("http://api.bronto.com/v4", "updateApiTokens");
-    private final static QName _DeleteLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteLoginsResponse");
-    private final static QName _ReadWebformsResponse_QNAME = new QName("http://api.bronto.com/v4", "readWebformsResponse");
-    private final static QName _ReadHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "readHeaderFooters");
-    private final static QName _AddConversion_QNAME = new QName("http://api.bronto.com/v4", "addConversion");
-    private final static QName _AddDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "addDeliveryGroup");
-    private final static QName _AddWorkflows_QNAME = new QName("http://api.bronto.com/v4", "addWorkflows");
-    private final static QName _AddSMSMessages_QNAME = new QName("http://api.bronto.com/v4", "addSMSMessages");
-    private final static QName _UpdateSMSDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateSMSDeliveriesResponse");
-    private final static QName _AddAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "addAccountsResponse");
-    private final static QName _DeleteMessageRules_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageRules");
-    private final static QName _UpdateApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "updateApiTokensResponse");
-    private final static QName _DeleteContacts_QNAME = new QName("http://api.bronto.com/v4", "deleteContacts");
-    private final static QName _AddContactEventResponse_QNAME = new QName("http://api.bronto.com/v4", "addContactEventResponse");
-    private final static QName _AddToDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "addToDeliveryGroup");
-    private final static QName _DeleteHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteHeaderFootersResponse");
-    private final static QName _DeleteFields_QNAME = new QName("http://api.bronto.com/v4", "deleteFields");
-    private final static QName _AddUpdateOrder_QNAME = new QName("http://api.bronto.com/v4", "addUpdateOrder");
-    private final static QName _UpdateLogins_QNAME = new QName("http://api.bronto.com/v4", "updateLogins");
-    private final static QName _ReadMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "readMessagesResponse");
-    private final static QName _AddOrUpdateOrdersResponse_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateOrdersResponse");
-    private final static QName _DeleteFromDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteFromDeliveryGroupResponse");
-    private final static QName _AddOrUpdateDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateDeliveryGroup");
-    private final static QName _AddWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "addWorkflowsResponse");
-    private final static QName _AddFields_QNAME = new QName("http://api.bronto.com/v4", "addFields");
-    private final static QName _UpdateContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateContactsResponse");
-    private final static QName _ReadRecentInboundActivitiesResponse_QNAME = new QName("http://api.bronto.com/v4", "readRecentInboundActivitiesResponse");
-    private final static QName _DeleteWorkflows_QNAME = new QName("http://api.bronto.com/v4", "deleteWorkflows");
-    private final static QName _ReadWorkflows_QNAME = new QName("http://api.bronto.com/v4", "readWorkflows");
-    private final static QName _ReadSegmentsResponse_QNAME = new QName("http://api.bronto.com/v4", "readSegmentsResponse");
-    private final static QName _ReadRecentInboundActivities_QNAME = new QName("http://api.bronto.com/v4", "readRecentInboundActivities");
-    private final static QName _DeleteSMSKeywordsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSKeywordsResponse");
-    private final static QName _AddLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "addLoginsResponse");
-    private final static QName _DeleteContentTags_QNAME = new QName("http://api.bronto.com/v4", "deleteContentTags");
-    private final static QName _ReadUnsubscribesResponse_QNAME = new QName("http://api.bronto.com/v4", "readUnsubscribesResponse");
-    private final static QName _UpdateMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateMessageRulesResponse");
-    private final static QName _DeleteSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSDeliveries");
-    private final static QName _ReadDeliveryGroups_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryGroups");
-    private final static QName _ReadBouncesResponse_QNAME = new QName("http://api.bronto.com/v4", "readBouncesResponse");
-    private final static QName _UpdateMessageRules_QNAME = new QName("http://api.bronto.com/v4", "updateMessageRules");
-    private final static QName _ApiException_QNAME = new QName("http://api.bronto.com/v4", "ApiException");
-    private final static QName _UpdateAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateAccountsResponse");
-    private final static QName _ReadFieldsResponse_QNAME = new QName("http://api.bronto.com/v4", "readFieldsResponse");
-    private final static QName _ReadActivitiesResponse_QNAME = new QName("http://api.bronto.com/v4", "readActivitiesResponse");
-    private final static QName _RemoveFromSMSKeyword_QNAME = new QName("http://api.bronto.com/v4", "removeFromSMSKeyword");
-    private final static QName _DeleteContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteContentTagsResponse");
-    private final static QName _ReadLogins_QNAME = new QName("http://api.bronto.com/v4", "readLogins");
-    private final static QName _DeleteLogins_QNAME = new QName("http://api.bronto.com/v4", "deleteLogins");
+    private final static QName _AddOrUpdateOrders_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateOrders");
+    private final static QName _AddLists_QNAME = new QName("http://api.bronto.com/v4", "addLists");
     private final static QName _ReadUnsubscribes_QNAME = new QName("http://api.bronto.com/v4", "readUnsubscribes");
-    private final static QName _AddToList_QNAME = new QName("http://api.bronto.com/v4", "addToList");
+    private final static QName _AddSMSMessages_QNAME = new QName("http://api.bronto.com/v4", "addSMSMessages");
     private final static QName _DeleteDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "deleteDeliveryGroup");
-    private final static QName _DeleteOrdersResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteOrdersResponse");
-    private final static QName _LoginResponse_QNAME = new QName("http://api.bronto.com/v4", "loginResponse");
-    private final static QName _ReadSMSDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "readSMSDeliveriesResponse");
-    private final static QName _UpdateDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveriesResponse");
-    private final static QName _UpdateContentTags_QNAME = new QName("http://api.bronto.com/v4", "updateContentTags");
-    private final static QName _UpdateMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateMessagesResponse");
-    private final static QName _DeleteFromDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "deleteFromDeliveryGroup");
-    private final static QName _ReadDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "readDeliveriesResponse");
-    private final static QName _UpdateWorkflows_QNAME = new QName("http://api.bronto.com/v4", "updateWorkflows");
-    private final static QName _AddSMSKeywordsResponse_QNAME = new QName("http://api.bronto.com/v4", "addSMSKeywordsResponse");
-    private final static QName _AddApiTokens_QNAME = new QName("http://api.bronto.com/v4", "addApiTokens");
-    private final static QName _ReadMessageFolders_QNAME = new QName("http://api.bronto.com/v4", "readMessageFolders");
-    private final static QName _UpdateAccounts_QNAME = new QName("http://api.bronto.com/v4", "updateAccounts");
-    private final static QName _UpdateSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "updateSMSDeliveries");
-    private final static QName _UpdateHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "updateHeaderFooters");
-    private final static QName _DeleteAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteAccountsResponse");
-    private final static QName _DeleteHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "deleteHeaderFooters");
-    private final static QName _SessionHeader_QNAME = new QName("http://api.bronto.com/v4", "sessionHeader");
     private final static QName _DeleteFieldsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteFieldsResponse");
+    private final static QName _UpdateFieldsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateFieldsResponse");
+    private final static QName _AddContactEventResponse_QNAME = new QName("http://api.bronto.com/v4", "addContactEventResponse");
+    private final static QName _ReadActivities_QNAME = new QName("http://api.bronto.com/v4", "readActivities");
+    private final static QName _ReadConversionsResponse_QNAME = new QName("http://api.bronto.com/v4", "readConversionsResponse");
+    private final static QName _SessionHeader_QNAME = new QName("http://api.bronto.com/v4", "sessionHeader");
+    private final static QName _ReadMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "readMessageRulesResponse");
+    private final static QName _UpdateMessageRules_QNAME = new QName("http://api.bronto.com/v4", "updateMessageRules");
+    private final static QName _ReadSMSDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "readSMSDeliveriesResponse");
+    private final static QName _UpdateSMSDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateSMSDeliveriesResponse");
+    private final static QName _DeleteContentTags_QNAME = new QName("http://api.bronto.com/v4", "deleteContentTags");
+    private final static QName _AddAccounts_QNAME = new QName("http://api.bronto.com/v4", "addAccounts");
+    private final static QName _UpdateSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateSMSMessagesResponse");
+    private final static QName _AddToSMSKeywordResponse_QNAME = new QName("http://api.bronto.com/v4", "addToSMSKeywordResponse");
     private final static QName _AddSMSDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "addSMSDeliveriesResponse");
+    private final static QName _ReadMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "readMessagesResponse");
+    private final static QName _DeleteDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteDeliveriesResponse");
+    private final static QName _ReadHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "readHeaderFootersResponse");
+    private final static QName _AddSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "addSMSDeliveries");
+    private final static QName _UpdateDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveryGroupResponse");
+    private final static QName _AddHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "addHeaderFooters");
+    private final static QName _AddMessageRules_QNAME = new QName("http://api.bronto.com/v4", "addMessageRules");
+    private final static QName _AddToSMSKeyword_QNAME = new QName("http://api.bronto.com/v4", "addToSMSKeyword");
+    private final static QName _ReadSMSKeywordsResponse_QNAME = new QName("http://api.bronto.com/v4", "readSMSKeywordsResponse");
+    private final static QName _AddMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "addMessagesResponse");
+    private final static QName _DeleteMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageFoldersResponse");
+    private final static QName _DeleteFromDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteFromDeliveryGroupResponse");
+    private final static QName _ReadDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "readDeliveriesResponse");
+    private final static QName _ReadSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "readSMSKeywords");
+    private final static QName _AddFieldsResponse_QNAME = new QName("http://api.bronto.com/v4", "addFieldsResponse");
+    private final static QName _AddContentTags_QNAME = new QName("http://api.bronto.com/v4", "addContentTags");
+    private final static QName _DeleteMessageFolders_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageFolders");
+    private final static QName _ReadWorkflows_QNAME = new QName("http://api.bronto.com/v4", "readWorkflows");
+    private final static QName _DeleteMessages_QNAME = new QName("http://api.bronto.com/v4", "deleteMessages");
+    private final static QName _ReadLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "readLoginsResponse");
+    private final static QName _ReadListsResponse_QNAME = new QName("http://api.bronto.com/v4", "readListsResponse");
+    private final static QName _UpdateApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "updateApiTokensResponse");
+    private final static QName _AddContacts_QNAME = new QName("http://api.bronto.com/v4", "addContacts");
     private final static QName _AddMessageFolders_QNAME = new QName("http://api.bronto.com/v4", "addMessageFolders");
+    private final static QName _ReadLists_QNAME = new QName("http://api.bronto.com/v4", "readLists");
+    private final static QName _ClearLists_QNAME = new QName("http://api.bronto.com/v4", "clearLists");
+    private final static QName _DeleteMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageRulesResponse");
+    private final static QName _ReadSegmentsResponse_QNAME = new QName("http://api.bronto.com/v4", "readSegmentsResponse");
+    private final static QName _UpdateDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveriesResponse");
+    private final static QName _DeleteDeliveries_QNAME = new QName("http://api.bronto.com/v4", "deleteDeliveries");
+    private final static QName _UpdateWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateWorkflowsResponse");
+    private final static QName _DeleteSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSMessagesResponse");
+    private final static QName _AddMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "addMessageFoldersResponse");
+    private final static QName _UpdateContentTags_QNAME = new QName("http://api.bronto.com/v4", "updateContentTags");
+    private final static QName _ReadSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "readSMSMessagesResponse");
+    private final static QName _DeleteHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "deleteHeaderFooters");
+    private final static QName _AddDeliveries_QNAME = new QName("http://api.bronto.com/v4", "addDeliveries");
+    private final static QName _AddUpdateOrderResponse_QNAME = new QName("http://api.bronto.com/v4", "addUpdateOrderResponse");
+    private final static QName _ApiException_QNAME = new QName("http://api.bronto.com/v4", "ApiException");
+    private final static QName _UpdateMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateMessageRulesResponse");
+    private final static QName _AddListsResponse_QNAME = new QName("http://api.bronto.com/v4", "addListsResponse");
+    private final static QName _UpdateMessages_QNAME = new QName("http://api.bronto.com/v4", "updateMessages");
+    private final static QName _AddHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "addHeaderFootersResponse");
+    private final static QName _DeleteLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteLoginsResponse");
+    private final static QName _AddAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "addAccountsResponse");
+    private final static QName _AddConversion_QNAME = new QName("http://api.bronto.com/v4", "addConversion");
+    private final static QName _ReadMessageFolders_QNAME = new QName("http://api.bronto.com/v4", "readMessageFolders");
+    private final static QName _AddMessages_QNAME = new QName("http://api.bronto.com/v4", "addMessages");
+    private final static QName _DeleteApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteApiTokensResponse");
+    private final static QName _ReadBounces_QNAME = new QName("http://api.bronto.com/v4", "readBounces");
+    private final static QName _RemoveFromSMSKeyword_QNAME = new QName("http://api.bronto.com/v4", "removeFromSMSKeyword");
+    private final static QName _AddLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "addLoginsResponse");
+    private final static QName _AddWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "addWorkflowsResponse");
+    private final static QName _ReadContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "readContactsResponse");
+    private final static QName _AddDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "addDeliveryGroup");
+    private final static QName _AddUpdateOrder_QNAME = new QName("http://api.bronto.com/v4", "addUpdateOrder");
+    private final static QName _AddDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "addDeliveriesResponse");
+    private final static QName _AddConversionResponse_QNAME = new QName("http://api.bronto.com/v4", "addConversionResponse");
+    private final static QName _AddDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "addDeliveryGroupResponse");
+    private final static QName _ReadWebforms_QNAME = new QName("http://api.bronto.com/v4", "readWebforms");
+    private final static QName _DeleteListsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteListsResponse");
+    private final static QName _UpdateSMSMessages_QNAME = new QName("http://api.bronto.com/v4", "updateSMSMessages");
+    private final static QName _ReadWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "readWorkflowsResponse");
+    private final static QName _UpdateAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateAccountsResponse");
+    private final static QName _AddContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "addContactsResponse");
+    private final static QName _Login_QNAME = new QName("http://api.bronto.com/v4", "login");
+    private final static QName _DeleteSMSKeywordsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSKeywordsResponse");
+    private final static QName _UpdateAccounts_QNAME = new QName("http://api.bronto.com/v4", "updateAccounts");
+    private final static QName _AddOrUpdateContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateContactsResponse");
+    private final static QName _ReadFields_QNAME = new QName("http://api.bronto.com/v4", "readFields");
+    private final static QName _ReadSMSMessages_QNAME = new QName("http://api.bronto.com/v4", "readSMSMessages");
+    private final static QName _DeleteSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSDeliveries");
+    private final static QName _ReadFieldsResponse_QNAME = new QName("http://api.bronto.com/v4", "readFieldsResponse");
+    private final static QName _DeleteLists_QNAME = new QName("http://api.bronto.com/v4", "deleteLists");
+    private final static QName _AddToListResponse_QNAME = new QName("http://api.bronto.com/v4", "addToListResponse");
+    private final static QName _DeleteContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteContentTagsResponse");
+    private final static QName _ReadBouncesResponse_QNAME = new QName("http://api.bronto.com/v4", "readBouncesResponse");
+    private final static QName _AddOrUpdateDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateDeliveryGroupResponse");
+    private final static QName _DeleteFields_QNAME = new QName("http://api.bronto.com/v4", "deleteFields");
+    private final static QName _ReadDeliveryRecipientsResponse_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryRecipientsResponse");
+    private final static QName _LoginResponse_QNAME = new QName("http://api.bronto.com/v4", "loginResponse");
+    private final static QName _ReadActivitiesResponse_QNAME = new QName("http://api.bronto.com/v4", "readActivitiesResponse");
+    private final static QName _AddMessageRulesResponse_QNAME = new QName("http://api.bronto.com/v4", "addMessageRulesResponse");
+    private final static QName _ReadConversions_QNAME = new QName("http://api.bronto.com/v4", "readConversions");
+    private final static QName _AddContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "addContentTagsResponse");
+    private final static QName _AddApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "addApiTokensResponse");
+    private final static QName _DeleteAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteAccountsResponse");
+    private final static QName _ReadDeliveryRecipients_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryRecipients");
     private final static QName _AddContactsToWorkflowResponse_QNAME = new QName("http://api.bronto.com/v4", "addContactsToWorkflowResponse");
-    private final static QName _ReadDeliveries_QNAME = new QName("http://api.bronto.com/v4", "readDeliveries");
+    private final static QName _AddOrUpdateOrdersResponse_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateOrdersResponse");
+    private final static QName _ReadAccountsResponse_QNAME = new QName("http://api.bronto.com/v4", "readAccountsResponse");
+    private final static QName _ReadLogins_QNAME = new QName("http://api.bronto.com/v4", "readLogins");
+    private final static QName _AddSMSKeywordsResponse_QNAME = new QName("http://api.bronto.com/v4", "addSMSKeywordsResponse");
+    private final static QName _UpdateDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveryGroup");
+    private final static QName _DeleteSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSKeywords");
+    private final static QName _AddSMSMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "addSMSMessagesResponse");
+    private final static QName _DeleteDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteDeliveryGroupResponse");
+    private final static QName _AddFields_QNAME = new QName("http://api.bronto.com/v4", "addFields");
+    private final static QName _UpdateSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "updateSMSKeywords");
+    private final static QName _UpdateDeliveries_QNAME = new QName("http://api.bronto.com/v4", "updateDeliveries");
+    private final static QName _ReadRecentOutboundActivitiesResponse_QNAME = new QName("http://api.bronto.com/v4", "readRecentOutboundActivitiesResponse");
+    private final static QName _UpdateLists_QNAME = new QName("http://api.bronto.com/v4", "updateLists");
+    private final static QName _ReadMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "readMessageFoldersResponse");
+    private final static QName _DeleteAccounts_QNAME = new QName("http://api.bronto.com/v4", "deleteAccounts");
+    private final static QName _AddToDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "addToDeliveryGroup");
     private final static QName _UpdateSMSKeywordsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateSMSKeywordsResponse");
+    private final static QName _AddOrUpdateDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "addOrUpdateDeliveryGroup");
+    private final static QName _RemoveFromListResponse_QNAME = new QName("http://api.bronto.com/v4", "removeFromListResponse");
+    private final static QName _UpdateWorkflows_QNAME = new QName("http://api.bronto.com/v4", "updateWorkflows");
+    private final static QName _AddApiTokens_QNAME = new QName("http://api.bronto.com/v4", "addApiTokens");
+    private final static QName _UpdateListsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateListsResponse");
+    private final static QName _DeleteContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteContactsResponse");
+    private final static QName _ReadSegments_QNAME = new QName("http://api.bronto.com/v4", "readSegments");
+    private final static QName _ReadDeliveryGroups_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryGroups");
+    private final static QName _UpdateLoginsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateLoginsResponse");
+    private final static QName _AddLogins_QNAME = new QName("http://api.bronto.com/v4", "addLogins");
+    private final static QName _ReadContacts_QNAME = new QName("http://api.bronto.com/v4", "readContacts");
+    private final static QName _UpdateContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateContentTagsResponse");
+    private final static QName _UpdateLogins_QNAME = new QName("http://api.bronto.com/v4", "updateLogins");
+    private final static QName _AddToDeliveryGroupResponse_QNAME = new QName("http://api.bronto.com/v4", "addToDeliveryGroupResponse");
+    private final static QName _ReadRecentOutboundActivities_QNAME = new QName("http://api.bronto.com/v4", "readRecentOutboundActivities");
+    private final static QName _AddContactEvent_QNAME = new QName("http://api.bronto.com/v4", "addContactEvent");
+    private final static QName _ReadDeliveryGroupsResponse_QNAME = new QName("http://api.bronto.com/v4", "readDeliveryGroupsResponse");
+    private final static QName _DeleteWorkflowsResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteWorkflowsResponse");
+    private final static QName _ReadApiTokens_QNAME = new QName("http://api.bronto.com/v4", "readApiTokens");
+    private final static QName _ReadContentTagsResponse_QNAME = new QName("http://api.bronto.com/v4", "readContentTagsResponse");
+    private final static QName _ReadDeliveries_QNAME = new QName("http://api.bronto.com/v4", "readDeliveries");
+    private final static QName _UpdateMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "updateMessagesResponse");
+    private final static QName _ReadWebformsResponse_QNAME = new QName("http://api.bronto.com/v4", "readWebformsResponse");
+    private final static QName _UpdateHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "updateHeaderFootersResponse");
+    private final static QName _UpdateApiTokens_QNAME = new QName("http://api.bronto.com/v4", "updateApiTokens");
+    private final static QName _AddWorkflows_QNAME = new QName("http://api.bronto.com/v4", "addWorkflows");
+    private final static QName _DeleteWorkflows_QNAME = new QName("http://api.bronto.com/v4", "deleteWorkflows");
+    private final static QName _DeleteContacts_QNAME = new QName("http://api.bronto.com/v4", "deleteContacts");
+    private final static QName _DeleteSMSDeliveriesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteSMSDeliveriesResponse");
+    private final static QName _AddSMSKeywords_QNAME = new QName("http://api.bronto.com/v4", "addSMSKeywords");
+    private final static QName _AddToList_QNAME = new QName("http://api.bronto.com/v4", "addToList");
+    private final static QName _DeleteHeaderFootersResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteHeaderFootersResponse");
+    private final static QName _ReadRecentInboundActivitiesResponse_QNAME = new QName("http://api.bronto.com/v4", "readRecentInboundActivitiesResponse");
+    private final static QName _UpdateContactsResponse_QNAME = new QName("http://api.bronto.com/v4", "updateContactsResponse");
+    private final static QName _UpdateSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "updateSMSDeliveries");
+    private final static QName _ReadApiTokensResponse_QNAME = new QName("http://api.bronto.com/v4", "readApiTokensResponse");
+    private final static QName _UpdateHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "updateHeaderFooters");
+    private final static QName _AddContactsToWorkflow_QNAME = new QName("http://api.bronto.com/v4", "addContactsToWorkflow");
+    private final static QName _ReadUnsubscribesResponse_QNAME = new QName("http://api.bronto.com/v4", "readUnsubscribesResponse");
+    private final static QName _DeleteOrdersResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteOrdersResponse");
+    private final static QName _UpdateFields_QNAME = new QName("http://api.bronto.com/v4", "updateFields");
+    private final static QName _DeleteMessagesResponse_QNAME = new QName("http://api.bronto.com/v4", "deleteMessagesResponse");
+    private final static QName _ReadAccounts_QNAME = new QName("http://api.bronto.com/v4", "readAccounts");
+    private final static QName _RemoveFromSMSKeywordResponse_QNAME = new QName("http://api.bronto.com/v4", "removeFromSMSKeywordResponse");
+    private final static QName _DeleteLogins_QNAME = new QName("http://api.bronto.com/v4", "deleteLogins");
+    private final static QName _ReadHeaderFooters_QNAME = new QName("http://api.bronto.com/v4", "readHeaderFooters");
+    private final static QName _UpdateMessageFolders_QNAME = new QName("http://api.bronto.com/v4", "updateMessageFolders");
+    private final static QName _DeleteMessageRules_QNAME = new QName("http://api.bronto.com/v4", "deleteMessageRules");
+    private final static QName _ReadSMSDeliveries_QNAME = new QName("http://api.bronto.com/v4", "readSMSDeliveries");
+    private final static QName _ReadRecentInboundActivities_QNAME = new QName("http://api.bronto.com/v4", "readRecentInboundActivities");
+    private final static QName _UpdateMessageFoldersResponse_QNAME = new QName("http://api.bronto.com/v4", "updateMessageFoldersResponse");
+    private final static QName _DeleteApiTokens_QNAME = new QName("http://api.bronto.com/v4", "deleteApiTokens");
+    private final static QName _DeleteOrders_QNAME = new QName("http://api.bronto.com/v4", "deleteOrders");
+    private final static QName _ReadMessageRules_QNAME = new QName("http://api.bronto.com/v4", "readMessageRules");
+    private final static QName _RemoveFromList_QNAME = new QName("http://api.bronto.com/v4", "removeFromList");
+    private final static QName _DeleteFromDeliveryGroup_QNAME = new QName("http://api.bronto.com/v4", "deleteFromDeliveryGroup");
+    private final static QName _ReadContentTags_QNAME = new QName("http://api.bronto.com/v4", "readContentTags");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: com.bronto.api.model
      * 
      */
     public ObjectFactory() {
-    }
-
-    /**
-     * Create an instance of {@link ReadListsResponse }
-     * 
-     */
-    public ReadListsResponse createReadListsResponse() {
-        return new ReadListsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadBounces }
-     * 
-     */
-    public ReadBounces createReadBounces() {
-        return new ReadBounces();
-    }
-
-    /**
-     * Create an instance of {@link DeleteMessagesResponse }
-     * 
-     */
-    public DeleteMessagesResponse createDeleteMessagesResponse() {
-        return new DeleteMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateSMSMessages }
-     * 
-     */
-    public UpdateSMSMessages createUpdateSMSMessages() {
-        return new UpdateSMSMessages();
-    }
-
-    /**
-     * Create an instance of {@link UpdateMessages }
-     * 
-     */
-    public UpdateMessages createUpdateMessages() {
-        return new UpdateMessages();
-    }
-
-    /**
-     * Create an instance of {@link ReadApiTokens }
-     * 
-     */
-    public ReadApiTokens createReadApiTokens() {
-        return new ReadApiTokens();
-    }
-
-    /**
-     * Create an instance of {@link UpdateFieldsResponse }
-     * 
-     */
-    public UpdateFieldsResponse createUpdateFieldsResponse() {
-        return new UpdateFieldsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddToSMSKeyword }
-     * 
-     */
-    public AddToSMSKeyword createAddToSMSKeyword() {
-        return new AddToSMSKeyword();
-    }
-
-    /**
-     * Create an instance of {@link UpdateDeliveries }
-     * 
-     */
-    public UpdateDeliveries createUpdateDeliveries() {
-        return new UpdateDeliveries();
-    }
-
-    /**
-     * Create an instance of {@link ReadDeliveryGroupsResponse }
-     * 
-     */
-    public ReadDeliveryGroupsResponse createReadDeliveryGroupsResponse() {
-        return new ReadDeliveryGroupsResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateDeliveryGroupResponse }
-     * 
-     */
-    public UpdateDeliveryGroupResponse createUpdateDeliveryGroupResponse() {
-        return new UpdateDeliveryGroupResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddToDeliveryGroupResponse }
-     * 
-     */
-    public AddToDeliveryGroupResponse createAddToDeliveryGroupResponse() {
-        return new AddToDeliveryGroupResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateSMSMessagesResponse }
-     * 
-     */
-    public UpdateSMSMessagesResponse createUpdateSMSMessagesResponse() {
-        return new UpdateSMSMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddContacts }
-     * 
-     */
-    public AddContacts createAddContacts() {
-        return new AddContacts();
-    }
-
-    /**
-     * Create an instance of {@link AddSMSDeliveries }
-     * 
-     */
-    public AddSMSDeliveries createAddSMSDeliveries() {
-        return new AddSMSDeliveries();
-    }
-
-    /**
-     * Create an instance of {@link AddLists }
-     * 
-     */
-    public AddLists createAddLists() {
-        return new AddLists();
-    }
-
-    /**
-     * Create an instance of {@link AddDeliveryGroup }
-     * 
-     */
-    public AddDeliveryGroup createAddDeliveryGroup() {
-        return new AddDeliveryGroup();
-    }
-
-    /**
-     * Create an instance of {@link ReadWebformsResponse }
-     * 
-     */
-    public ReadWebformsResponse createReadWebformsResponse() {
-        return new ReadWebformsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadHeaderFooters }
-     * 
-     */
-    public ReadHeaderFooters createReadHeaderFooters() {
-        return new ReadHeaderFooters();
-    }
-
-    /**
-     * Create an instance of {@link AddConversion }
-     * 
-     */
-    public AddConversion createAddConversion() {
-        return new AddConversion();
-    }
-
-    /**
-     * Create an instance of {@link DeleteSMSMessages }
-     * 
-     */
-    public DeleteSMSMessages createDeleteSMSMessages() {
-        return new DeleteSMSMessages();
-    }
-
-    /**
-     * Create an instance of {@link ReadSMSMessagesResponse }
-     * 
-     */
-    public ReadSMSMessagesResponse createReadSMSMessagesResponse() {
-        return new ReadSMSMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateApiTokens }
-     * 
-     */
-    public UpdateApiTokens createUpdateApiTokens() {
-        return new UpdateApiTokens();
-    }
-
-    /**
-     * Create an instance of {@link DeleteLoginsResponse }
-     * 
-     */
-    public DeleteLoginsResponse createDeleteLoginsResponse() {
-        return new DeleteLoginsResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteMessageRules }
-     * 
-     */
-    public DeleteMessageRules createDeleteMessageRules() {
-        return new DeleteMessageRules();
-    }
-
-    /**
-     * Create an instance of {@link DeleteContacts }
-     * 
-     */
-    public DeleteContacts createDeleteContacts() {
-        return new DeleteContacts();
-    }
-
-    /**
-     * Create an instance of {@link UpdateApiTokensResponse }
-     * 
-     */
-    public UpdateApiTokensResponse createUpdateApiTokensResponse() {
-        return new UpdateApiTokensResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddAccountsResponse }
-     * 
-     */
-    public AddAccountsResponse createAddAccountsResponse() {
-        return new AddAccountsResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateSMSDeliveriesResponse }
-     * 
-     */
-    public UpdateSMSDeliveriesResponse createUpdateSMSDeliveriesResponse() {
-        return new UpdateSMSDeliveriesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddSMSMessages }
-     * 
-     */
-    public AddSMSMessages createAddSMSMessages() {
-        return new AddSMSMessages();
-    }
-
-    /**
-     * Create an instance of {@link AddWorkflows }
-     * 
-     */
-    public AddWorkflows createAddWorkflows() {
-        return new AddWorkflows();
-    }
-
-    /**
-     * Create an instance of {@link AddUpdateOrder }
-     * 
-     */
-    public AddUpdateOrder createAddUpdateOrder() {
-        return new AddUpdateOrder();
-    }
-
-    /**
-     * Create an instance of {@link DeleteFields }
-     * 
-     */
-    public DeleteFields createDeleteFields() {
-        return new DeleteFields();
-    }
-
-    /**
-     * Create an instance of {@link DeleteHeaderFootersResponse }
-     * 
-     */
-    public DeleteHeaderFootersResponse createDeleteHeaderFootersResponse() {
-        return new DeleteHeaderFootersResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddToDeliveryGroup }
-     * 
-     */
-    public AddToDeliveryGroup createAddToDeliveryGroup() {
-        return new AddToDeliveryGroup();
-    }
-
-    /**
-     * Create an instance of {@link UpdateLogins }
-     * 
-     */
-    public UpdateLogins createUpdateLogins() {
-        return new UpdateLogins();
-    }
-
-    /**
-     * Create an instance of {@link AddContactEventResponse }
-     * 
-     */
-    public AddContactEventResponse createAddContactEventResponse() {
-        return new AddContactEventResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddWorkflowsResponse }
-     * 
-     */
-    public AddWorkflowsResponse createAddWorkflowsResponse() {
-        return new AddWorkflowsResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateContactsResponse }
-     * 
-     */
-    public UpdateContactsResponse createUpdateContactsResponse() {
-        return new UpdateContactsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddFields }
-     * 
-     */
-    public AddFields createAddFields() {
-        return new AddFields();
-    }
-
-    /**
-     * Create an instance of {@link AddOrUpdateOrdersResponse }
-     * 
-     */
-    public AddOrUpdateOrdersResponse createAddOrUpdateOrdersResponse() {
-        return new AddOrUpdateOrdersResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadMessagesResponse }
-     * 
-     */
-    public ReadMessagesResponse createReadMessagesResponse() {
-        return new ReadMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddOrUpdateDeliveryGroup }
-     * 
-     */
-    public AddOrUpdateDeliveryGroup createAddOrUpdateDeliveryGroup() {
-        return new AddOrUpdateDeliveryGroup();
-    }
-
-    /**
-     * Create an instance of {@link DeleteFromDeliveryGroupResponse }
-     * 
-     */
-    public DeleteFromDeliveryGroupResponse createDeleteFromDeliveryGroupResponse() {
-        return new DeleteFromDeliveryGroupResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadWorkflows }
-     * 
-     */
-    public ReadWorkflows createReadWorkflows() {
-        return new ReadWorkflows();
-    }
-
-    /**
-     * Create an instance of {@link ReadRecentInboundActivities }
-     * 
-     */
-    public ReadRecentInboundActivities createReadRecentInboundActivities() {
-        return new ReadRecentInboundActivities();
-    }
-
-    /**
-     * Create an instance of {@link ReadSegmentsResponse }
-     * 
-     */
-    public ReadSegmentsResponse createReadSegmentsResponse() {
-        return new ReadSegmentsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadRecentInboundActivitiesResponse }
-     * 
-     */
-    public ReadRecentInboundActivitiesResponse createReadRecentInboundActivitiesResponse() {
-        return new ReadRecentInboundActivitiesResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteWorkflows }
-     * 
-     */
-    public DeleteWorkflows createDeleteWorkflows() {
-        return new DeleteWorkflows();
-    }
-
-    /**
-     * Create an instance of {@link DeleteContentTags }
-     * 
-     */
-    public DeleteContentTags createDeleteContentTags() {
-        return new DeleteContentTags();
-    }
-
-    /**
-     * Create an instance of {@link DeleteSMSKeywordsResponse }
-     * 
-     */
-    public DeleteSMSKeywordsResponse createDeleteSMSKeywordsResponse() {
-        return new DeleteSMSKeywordsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddLoginsResponse }
-     * 
-     */
-    public AddLoginsResponse createAddLoginsResponse() {
-        return new AddLoginsResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateMessageRulesResponse }
-     * 
-     */
-    public UpdateMessageRulesResponse createUpdateMessageRulesResponse() {
-        return new UpdateMessageRulesResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteSMSDeliveries }
-     * 
-     */
-    public DeleteSMSDeliveries createDeleteSMSDeliveries() {
-        return new DeleteSMSDeliveries();
-    }
-
-    /**
-     * Create an instance of {@link ReadUnsubscribesResponse }
-     * 
-     */
-    public ReadUnsubscribesResponse createReadUnsubscribesResponse() {
-        return new ReadUnsubscribesResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadActivitiesResponse }
-     * 
-     */
-    public ReadActivitiesResponse createReadActivitiesResponse() {
-        return new ReadActivitiesResponse();
-    }
-
-    /**
-     * Create an instance of {@link RemoveFromSMSKeyword }
-     * 
-     */
-    public RemoveFromSMSKeyword createRemoveFromSMSKeyword() {
-        return new RemoveFromSMSKeyword();
-    }
-
-    /**
-     * Create an instance of {@link DeleteContentTagsResponse }
-     * 
-     */
-    public DeleteContentTagsResponse createDeleteContentTagsResponse() {
-        return new DeleteContentTagsResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateMessageRules }
-     * 
-     */
-    public UpdateMessageRules createUpdateMessageRules() {
-        return new UpdateMessageRules();
-    }
-
-    /**
-     * Create an instance of {@link ReadDeliveryGroups }
-     * 
-     */
-    public ReadDeliveryGroups createReadDeliveryGroups() {
-        return new ReadDeliveryGroups();
-    }
-
-    /**
-     * Create an instance of {@link ReadBouncesResponse }
-     * 
-     */
-    public ReadBouncesResponse createReadBouncesResponse() {
-        return new ReadBouncesResponse();
-    }
-
-    /**
-     * Create an instance of {@link ApiException }
-     * 
-     */
-    public ApiException createApiException() {
-        return new ApiException();
-    }
-
-    /**
-     * Create an instance of {@link UpdateAccountsResponse }
-     * 
-     */
-    public UpdateAccountsResponse createUpdateAccountsResponse() {
-        return new UpdateAccountsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadFieldsResponse }
-     * 
-     */
-    public ReadFieldsResponse createReadFieldsResponse() {
-        return new ReadFieldsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadUnsubscribes }
-     * 
-     */
-    public ReadUnsubscribes createReadUnsubscribes() {
-        return new ReadUnsubscribes();
-    }
-
-    /**
-     * Create an instance of {@link AddToList }
-     * 
-     */
-    public AddToList createAddToList() {
-        return new AddToList();
-    }
-
-    /**
-     * Create an instance of {@link ReadLogins }
-     * 
-     */
-    public ReadLogins createReadLogins() {
-        return new ReadLogins();
-    }
-
-    /**
-     * Create an instance of {@link DeleteLogins }
-     * 
-     */
-    public DeleteLogins createDeleteLogins() {
-        return new DeleteLogins();
-    }
-
-    /**
-     * Create an instance of {@link UpdateMessagesResponse }
-     * 
-     */
-    public UpdateMessagesResponse createUpdateMessagesResponse() {
-        return new UpdateMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteFromDeliveryGroup }
-     * 
-     */
-    public DeleteFromDeliveryGroup createDeleteFromDeliveryGroup() {
-        return new DeleteFromDeliveryGroup();
-    }
-
-    /**
-     * Create an instance of {@link ReadSMSDeliveriesResponse }
-     * 
-     */
-    public ReadSMSDeliveriesResponse createReadSMSDeliveriesResponse() {
-        return new ReadSMSDeliveriesResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteDeliveryGroup }
-     * 
-     */
-    public DeleteDeliveryGroup createDeleteDeliveryGroup() {
-        return new DeleteDeliveryGroup();
-    }
-
-    /**
-     * Create an instance of {@link DeleteOrdersResponse }
-     * 
-     */
-    public DeleteOrdersResponse createDeleteOrdersResponse() {
-        return new DeleteOrdersResponse();
-    }
-
-    /**
-     * Create an instance of {@link LoginResponse }
-     * 
-     */
-    public LoginResponse createLoginResponse() {
-        return new LoginResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateContentTags }
-     * 
-     */
-    public UpdateContentTags createUpdateContentTags() {
-        return new UpdateContentTags();
-    }
-
-    /**
-     * Create an instance of {@link UpdateDeliveriesResponse }
-     * 
-     */
-    public UpdateDeliveriesResponse createUpdateDeliveriesResponse() {
-        return new UpdateDeliveriesResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadMessageFolders }
-     * 
-     */
-    public ReadMessageFolders createReadMessageFolders() {
-        return new ReadMessageFolders();
-    }
-
-    /**
-     * Create an instance of {@link UpdateAccounts }
-     * 
-     */
-    public UpdateAccounts createUpdateAccounts() {
-        return new UpdateAccounts();
-    }
-
-    /**
-     * Create an instance of {@link UpdateWorkflows }
-     * 
-     */
-    public UpdateWorkflows createUpdateWorkflows() {
-        return new UpdateWorkflows();
-    }
-
-    /**
-     * Create an instance of {@link AddSMSKeywordsResponse }
-     * 
-     */
-    public AddSMSKeywordsResponse createAddSMSKeywordsResponse() {
-        return new AddSMSKeywordsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadDeliveriesResponse }
-     * 
-     */
-    public ReadDeliveriesResponse createReadDeliveriesResponse() {
-        return new ReadDeliveriesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddApiTokens }
-     * 
-     */
-    public AddApiTokens createAddApiTokens() {
-        return new AddApiTokens();
-    }
-
-    /**
-     * Create an instance of {@link UpdateSMSDeliveries }
-     * 
-     */
-    public UpdateSMSDeliveries createUpdateSMSDeliveries() {
-        return new UpdateSMSDeliveries();
-    }
-
-    /**
-     * Create an instance of {@link UpdateHeaderFooters }
-     * 
-     */
-    public UpdateHeaderFooters createUpdateHeaderFooters() {
-        return new UpdateHeaderFooters();
-    }
-
-    /**
-     * Create an instance of {@link DeleteAccountsResponse }
-     * 
-     */
-    public DeleteAccountsResponse createDeleteAccountsResponse() {
-        return new DeleteAccountsResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteHeaderFooters }
-     * 
-     */
-    public DeleteHeaderFooters createDeleteHeaderFooters() {
-        return new DeleteHeaderFooters();
-    }
-
-    /**
-     * Create an instance of {@link AddContactsToWorkflowResponse }
-     * 
-     */
-    public AddContactsToWorkflowResponse createAddContactsToWorkflowResponse() {
-        return new AddContactsToWorkflowResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateSMSKeywordsResponse }
-     * 
-     */
-    public UpdateSMSKeywordsResponse createUpdateSMSKeywordsResponse() {
-        return new UpdateSMSKeywordsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadDeliveries }
-     * 
-     */
-    public ReadDeliveries createReadDeliveries() {
-        return new ReadDeliveries();
-    }
-
-    /**
-     * Create an instance of {@link SessionHeader }
-     * 
-     */
-    public SessionHeader createSessionHeader() {
-        return new SessionHeader();
-    }
-
-    /**
-     * Create an instance of {@link DeleteFieldsResponse }
-     * 
-     */
-    public DeleteFieldsResponse createDeleteFieldsResponse() {
-        return new DeleteFieldsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddSMSDeliveriesResponse }
-     * 
-     */
-    public AddSMSDeliveriesResponse createAddSMSDeliveriesResponse() {
-        return new AddSMSDeliveriesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddMessageFolders }
-     * 
-     */
-    public AddMessageFolders createAddMessageFolders() {
-        return new AddMessageFolders();
-    }
-
-    /**
-     * Create an instance of {@link AddApiTokensResponse }
-     * 
-     */
-    public AddApiTokensResponse createAddApiTokensResponse() {
-        return new AddApiTokensResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteDeliveriesResponse }
-     * 
-     */
-    public DeleteDeliveriesResponse createDeleteDeliveriesResponse() {
-        return new DeleteDeliveriesResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateContentTagsResponse }
-     * 
-     */
-    public UpdateContentTagsResponse createUpdateContentTagsResponse() {
-        return new UpdateContentTagsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddConversionResponse }
-     * 
-     */
-    public AddConversionResponse createAddConversionResponse() {
-        return new AddConversionResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadContactsResponse }
-     * 
-     */
-    public ReadContactsResponse createReadContactsResponse() {
-        return new ReadContactsResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteApiTokensResponse }
-     * 
-     */
-    public DeleteApiTokensResponse createDeleteApiTokensResponse() {
-        return new DeleteApiTokensResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadSegments }
-     * 
-     */
-    public ReadSegments createReadSegments() {
-        return new ReadSegments();
-    }
-
-    /**
-     * Create an instance of {@link ReadDeliveryRecipientsResponse }
-     * 
-     */
-    public ReadDeliveryRecipientsResponse createReadDeliveryRecipientsResponse() {
-        return new ReadDeliveryRecipientsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadMessageFoldersResponse }
-     * 
-     */
-    public ReadMessageFoldersResponse createReadMessageFoldersResponse() {
-        return new ReadMessageFoldersResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadConversionsResponse }
-     * 
-     */
-    public ReadConversionsResponse createReadConversionsResponse() {
-        return new ReadConversionsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadRecentOutboundActivitiesResponse }
-     * 
-     */
-    public ReadRecentOutboundActivitiesResponse createReadRecentOutboundActivitiesResponse() {
-        return new ReadRecentOutboundActivitiesResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadFields }
-     * 
-     */
-    public ReadFields createReadFields() {
-        return new ReadFields();
-    }
-
-    /**
-     * Create an instance of {@link AddSMSKeywords }
-     * 
-     */
-    public AddSMSKeywords createAddSMSKeywords() {
-        return new AddSMSKeywords();
-    }
-
-    /**
-     * Create an instance of {@link ReadActivities }
-     * 
-     */
-    public ReadActivities createReadActivities() {
-        return new ReadActivities();
-    }
-
-    /**
-     * Create an instance of {@link AddToSMSKeywordResponse }
-     * 
-     */
-    public AddToSMSKeywordResponse createAddToSMSKeywordResponse() {
-        return new AddToSMSKeywordResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadRecentOutboundActivities }
-     * 
-     */
-    public ReadRecentOutboundActivities createReadRecentOutboundActivities() {
-        return new ReadRecentOutboundActivities();
-    }
-
-    /**
-     * Create an instance of {@link UpdateMessageFolders }
-     * 
-     */
-    public UpdateMessageFolders createUpdateMessageFolders() {
-        return new UpdateMessageFolders();
-    }
-
-    /**
-     * Create an instance of {@link AddLogins }
-     * 
-     */
-    public AddLogins createAddLogins() {
-        return new AddLogins();
-    }
-
-    /**
-     * Create an instance of {@link ClearLists }
-     * 
-     */
-    public ClearLists createClearLists() {
-        return new ClearLists();
-    }
-
-    /**
-     * Create an instance of {@link AddDeliveryGroupResponse }
-     * 
-     */
-    public AddDeliveryGroupResponse createAddDeliveryGroupResponse() {
-        return new AddDeliveryGroupResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddMessages }
-     * 
-     */
-    public AddMessages createAddMessages() {
-        return new AddMessages();
-    }
-
-    /**
-     * Create an instance of {@link DeleteDeliveries }
-     * 
-     */
-    public DeleteDeliveries createDeleteDeliveries() {
-        return new DeleteDeliveries();
-    }
-
-    /**
-     * Create an instance of {@link Login }
-     * 
-     */
-    public Login createLogin() {
-        return new Login();
-    }
-
-    /**
-     * Create an instance of {@link UpdateMessageFoldersResponse }
-     * 
-     */
-    public UpdateMessageFoldersResponse createUpdateMessageFoldersResponse() {
-        return new UpdateMessageFoldersResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadConversions }
-     * 
-     */
-    public ReadConversions createReadConversions() {
-        return new ReadConversions();
-    }
-
-    /**
-     * Create an instance of {@link AddOrUpdateOrders }
-     * 
-     */
-    public AddOrUpdateOrders createAddOrUpdateOrders() {
-        return new AddOrUpdateOrders();
-    }
-
-    /**
-     * Create an instance of {@link ReadAccountsResponse }
-     * 
-     */
-    public ReadAccountsResponse createReadAccountsResponse() {
-        return new ReadAccountsResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateWorkflowsResponse }
-     * 
-     */
-    public UpdateWorkflowsResponse createUpdateWorkflowsResponse() {
-        return new UpdateWorkflowsResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteListsResponse }
-     * 
-     */
-    public DeleteListsResponse createDeleteListsResponse() {
-        return new DeleteListsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadApiTokensResponse }
-     * 
-     */
-    public ReadApiTokensResponse createReadApiTokensResponse() {
-        return new ReadApiTokensResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateDeliveryGroup }
-     * 
-     */
-    public UpdateDeliveryGroup createUpdateDeliveryGroup() {
-        return new UpdateDeliveryGroup();
-    }
-
-    /**
-     * Create an instance of {@link ReadSMSDeliveries }
-     * 
-     */
-    public ReadSMSDeliveries createReadSMSDeliveries() {
-        return new ReadSMSDeliveries();
-    }
-
-    /**
-     * Create an instance of {@link UpdateLists }
-     * 
-     */
-    public UpdateLists createUpdateLists() {
-        return new UpdateLists();
-    }
-
-    /**
-     * Create an instance of {@link AddSMSMessagesResponse }
-     * 
-     */
-    public AddSMSMessagesResponse createAddSMSMessagesResponse() {
-        return new AddSMSMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadHeaderFootersResponse }
-     * 
-     */
-    public ReadHeaderFootersResponse createReadHeaderFootersResponse() {
-        return new ReadHeaderFootersResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateSMSKeywords }
-     * 
-     */
-    public UpdateSMSKeywords createUpdateSMSKeywords() {
-        return new UpdateSMSKeywords();
-    }
-
-    /**
-     * Create an instance of {@link DeleteDeliveryGroupResponse }
-     * 
-     */
-    public DeleteDeliveryGroupResponse createDeleteDeliveryGroupResponse() {
-        return new DeleteDeliveryGroupResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadDeliveryRecipients }
-     * 
-     */
-    public ReadDeliveryRecipients createReadDeliveryRecipients() {
-        return new ReadDeliveryRecipients();
-    }
-
-    /**
-     * Create an instance of {@link ReadSMSMessages }
-     * 
-     */
-    public ReadSMSMessages createReadSMSMessages() {
-        return new ReadSMSMessages();
-    }
-
-    /**
-     * Create an instance of {@link AddContactEvent }
-     * 
-     */
-    public AddContactEvent createAddContactEvent() {
-        return new AddContactEvent();
-    }
-
-    /**
-     * Create an instance of {@link DeleteSMSMessagesResponse }
-     * 
-     */
-    public DeleteSMSMessagesResponse createDeleteSMSMessagesResponse() {
-        return new DeleteSMSMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadMessages }
-     * 
-     */
-    public ReadMessages createReadMessages() {
-        return new ReadMessages();
-    }
-
-    /**
-     * Create an instance of {@link UpdateHeaderFootersResponse }
-     * 
-     */
-    public UpdateHeaderFootersResponse createUpdateHeaderFootersResponse() {
-        return new UpdateHeaderFootersResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteSMSDeliveriesResponse }
-     * 
-     */
-    public DeleteSMSDeliveriesResponse createDeleteSMSDeliveriesResponse() {
-        return new DeleteSMSDeliveriesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddMessageRulesResponse }
-     * 
-     */
-    public AddMessageRulesResponse createAddMessageRulesResponse() {
-        return new AddMessageRulesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddHeaderFooters }
-     * 
-     */
-    public AddHeaderFooters createAddHeaderFooters() {
-        return new AddHeaderFooters();
-    }
-
-    /**
-     * Create an instance of {@link DeleteLists }
-     * 
-     */
-    public DeleteLists createDeleteLists() {
-        return new DeleteLists();
-    }
-
-    /**
-     * Create an instance of {@link DeleteMessageRulesResponse }
-     * 
-     */
-    public DeleteMessageRulesResponse createDeleteMessageRulesResponse() {
-        return new DeleteMessageRulesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddUpdateOrderResponse }
-     * 
-     */
-    public AddUpdateOrderResponse createAddUpdateOrderResponse() {
-        return new AddUpdateOrderResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteApiTokens }
-     * 
-     */
-    public DeleteApiTokens createDeleteApiTokens() {
-        return new DeleteApiTokens();
-    }
-
-    /**
-     * Create an instance of {@link AddHeaderFootersResponse }
-     * 
-     */
-    public AddHeaderFootersResponse createAddHeaderFootersResponse() {
-        return new AddHeaderFootersResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadContentTags }
-     * 
-     */
-    public ReadContentTags createReadContentTags() {
-        return new ReadContentTags();
-    }
-
-    /**
-     * Create an instance of {@link AddContactsToWorkflow }
-     * 
-     */
-    public AddContactsToWorkflow createAddContactsToWorkflow() {
-        return new AddContactsToWorkflow();
-    }
-
-    /**
-     * Create an instance of {@link ReadWebforms }
-     * 
-     */
-    public ReadWebforms createReadWebforms() {
-        return new ReadWebforms();
-    }
-
-    /**
-     * Create an instance of {@link ReadMessageRules }
-     * 
-     */
-    public ReadMessageRules createReadMessageRules() {
-        return new ReadMessageRules();
-    }
-
-    /**
-     * Create an instance of {@link DeleteOrders }
-     * 
-     */
-    public DeleteOrders createDeleteOrders() {
-        return new DeleteOrders();
-    }
-
-    /**
-     * Create an instance of {@link AddToListResponse }
-     * 
-     */
-    public AddToListResponse createAddToListResponse() {
-        return new AddToListResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadLists }
-     * 
-     */
-    public ReadLists createReadLists() {
-        return new ReadLists();
-    }
-
-    /**
-     * Create an instance of {@link AddListsResponse }
-     * 
-     */
-    public AddListsResponse createAddListsResponse() {
-        return new AddListsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ClearListsResponse }
-     * 
-     */
-    public ClearListsResponse createClearListsResponse() {
-        return new ClearListsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddMessageRules }
-     * 
-     */
-    public AddMessageRules createAddMessageRules() {
-        return new AddMessageRules();
     }
 
     /**
@@ -1461,203 +229,11 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link AddOrUpdateContacts }
-     * 
-     */
-    public AddOrUpdateContacts createAddOrUpdateContacts() {
-        return new AddOrUpdateContacts();
-    }
-
-    /**
-     * Create an instance of {@link DeleteWorkflowsResponse }
-     * 
-     */
-    public DeleteWorkflowsResponse createDeleteWorkflowsResponse() {
-        return new DeleteWorkflowsResponse();
-    }
-
-    /**
-     * Create an instance of {@link RemoveFromSMSKeywordResponse }
-     * 
-     */
-    public RemoveFromSMSKeywordResponse createRemoveFromSMSKeywordResponse() {
-        return new RemoveFromSMSKeywordResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadSMSKeywords }
-     * 
-     */
-    public ReadSMSKeywords createReadSMSKeywords() {
-        return new ReadSMSKeywords();
-    }
-
-    /**
-     * Create an instance of {@link AddAccounts }
-     * 
-     */
-    public AddAccounts createAddAccounts() {
-        return new AddAccounts();
-    }
-
-    /**
      * Create an instance of {@link ReadLoginsResponse }
      * 
      */
     public ReadLoginsResponse createReadLoginsResponse() {
         return new ReadLoginsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddMessageFoldersResponse }
-     * 
-     */
-    public AddMessageFoldersResponse createAddMessageFoldersResponse() {
-        return new AddMessageFoldersResponse();
-    }
-
-    /**
-     * Create an instance of {@link UpdateFields }
-     * 
-     */
-    public UpdateFields createUpdateFields() {
-        return new UpdateFields();
-    }
-
-    /**
-     * Create an instance of {@link ReadMessageRulesResponse }
-     * 
-     */
-    public ReadMessageRulesResponse createReadMessageRulesResponse() {
-        return new ReadMessageRulesResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddFieldsResponse }
-     * 
-     */
-    public AddFieldsResponse createAddFieldsResponse() {
-        return new AddFieldsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadWorkflowsResponse }
-     * 
-     */
-    public ReadWorkflowsResponse createReadWorkflowsResponse() {
-        return new ReadWorkflowsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddContentTagsResponse }
-     * 
-     */
-    public AddContentTagsResponse createAddContentTagsResponse() {
-        return new AddContentTagsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadAccounts }
-     * 
-     */
-    public ReadAccounts createReadAccounts() {
-        return new ReadAccounts();
-    }
-
-    /**
-     * Create an instance of {@link UpdateListsResponse }
-     * 
-     */
-    public UpdateListsResponse createUpdateListsResponse() {
-        return new UpdateListsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadSMSKeywordsResponse }
-     * 
-     */
-    public ReadSMSKeywordsResponse createReadSMSKeywordsResponse() {
-        return new ReadSMSKeywordsResponse();
-    }
-
-    /**
-     * Create an instance of {@link ReadContentTagsResponse }
-     * 
-     */
-    public ReadContentTagsResponse createReadContentTagsResponse() {
-        return new ReadContentTagsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddMessagesResponse }
-     * 
-     */
-    public AddMessagesResponse createAddMessagesResponse() {
-        return new AddMessagesResponse();
-    }
-
-    /**
-     * Create an instance of {@link RemoveFromListResponse }
-     * 
-     */
-    public RemoveFromListResponse createRemoveFromListResponse() {
-        return new RemoveFromListResponse();
-    }
-
-    /**
-     * Create an instance of {@link RemoveFromList }
-     * 
-     */
-    public RemoveFromList createRemoveFromList() {
-        return new RemoveFromList();
-    }
-
-    /**
-     * Create an instance of {@link UpdateLoginsResponse }
-     * 
-     */
-    public UpdateLoginsResponse createUpdateLoginsResponse() {
-        return new UpdateLoginsResponse();
-    }
-
-    /**
-     * Create an instance of {@link AddOrUpdateDeliveryGroupResponse }
-     * 
-     */
-    public AddOrUpdateDeliveryGroupResponse createAddOrUpdateDeliveryGroupResponse() {
-        return new AddOrUpdateDeliveryGroupResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteMessageFoldersResponse }
-     * 
-     */
-    public DeleteMessageFoldersResponse createDeleteMessageFoldersResponse() {
-        return new DeleteMessageFoldersResponse();
-    }
-
-    /**
-     * Create an instance of {@link DeleteSMSKeywords }
-     * 
-     */
-    public DeleteSMSKeywords createDeleteSMSKeywords() {
-        return new DeleteSMSKeywords();
-    }
-
-    /**
-     * Create an instance of {@link DeleteAccounts }
-     * 
-     */
-    public DeleteAccounts createDeleteAccounts() {
-        return new DeleteAccounts();
-    }
-
-    /**
-     * Create an instance of {@link DeleteContactsResponse }
-     * 
-     */
-    public DeleteContactsResponse createDeleteContactsResponse() {
-        return new DeleteContactsResponse();
     }
 
     /**
@@ -1669,43 +245,387 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link ReadContacts }
+     * Create an instance of {@link DeleteMessageFolders }
      * 
      */
-    public ReadContacts createReadContacts() {
-        return new ReadContacts();
+    public DeleteMessageFolders createDeleteMessageFolders() {
+        return new DeleteMessageFolders();
     }
 
     /**
-     * Create an instance of {@link AddDeliveries }
+     * Create an instance of {@link ReadWorkflows }
      * 
      */
-    public AddDeliveries createAddDeliveries() {
-        return new AddDeliveries();
+    public ReadWorkflows createReadWorkflows() {
+        return new ReadWorkflows();
     }
 
     /**
-     * Create an instance of {@link AddDeliveriesResponse }
+     * Create an instance of {@link UpdateDeliveriesResponse }
      * 
      */
-    public AddDeliveriesResponse createAddDeliveriesResponse() {
-        return new AddDeliveriesResponse();
+    public UpdateDeliveriesResponse createUpdateDeliveriesResponse() {
+        return new UpdateDeliveriesResponse();
     }
 
     /**
-     * Create an instance of {@link AddOrUpdateContactsResponse }
+     * Create an instance of {@link ClearLists }
      * 
      */
-    public AddOrUpdateContactsResponse createAddOrUpdateContactsResponse() {
-        return new AddOrUpdateContactsResponse();
+    public ClearLists createClearLists() {
+        return new ClearLists();
     }
 
     /**
-     * Create an instance of {@link AddContactsResponse }
+     * Create an instance of {@link DeleteMessageRulesResponse }
      * 
      */
-    public AddContactsResponse createAddContactsResponse() {
-        return new AddContactsResponse();
+    public DeleteMessageRulesResponse createDeleteMessageRulesResponse() {
+        return new DeleteMessageRulesResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadSegmentsResponse }
+     * 
+     */
+    public ReadSegmentsResponse createReadSegmentsResponse() {
+        return new ReadSegmentsResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteDeliveries }
+     * 
+     */
+    public DeleteDeliveries createDeleteDeliveries() {
+        return new DeleteDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link UpdateWorkflowsResponse }
+     * 
+     */
+    public UpdateWorkflowsResponse createUpdateWorkflowsResponse() {
+        return new UpdateWorkflowsResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateApiTokensResponse }
+     * 
+     */
+    public UpdateApiTokensResponse createUpdateApiTokensResponse() {
+        return new UpdateApiTokensResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadListsResponse }
+     * 
+     */
+    public ReadListsResponse createReadListsResponse() {
+        return new ReadListsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadLists }
+     * 
+     */
+    public ReadLists createReadLists() {
+        return new ReadLists();
+    }
+
+    /**
+     * Create an instance of {@link AddContacts }
+     * 
+     */
+    public AddContacts createAddContacts() {
+        return new AddContacts();
+    }
+
+    /**
+     * Create an instance of {@link AddMessageFolders }
+     * 
+     */
+    public AddMessageFolders createAddMessageFolders() {
+        return new AddMessageFolders();
+    }
+
+    /**
+     * Create an instance of {@link AddMessageRules }
+     * 
+     */
+    public AddMessageRules createAddMessageRules() {
+        return new AddMessageRules();
+    }
+
+    /**
+     * Create an instance of {@link AddToSMSKeyword }
+     * 
+     */
+    public AddToSMSKeyword createAddToSMSKeyword() {
+        return new AddToSMSKeyword();
+    }
+
+    /**
+     * Create an instance of {@link ReadSMSKeywordsResponse }
+     * 
+     */
+    public ReadSMSKeywordsResponse createReadSMSKeywordsResponse() {
+        return new ReadSMSKeywordsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddHeaderFooters }
+     * 
+     */
+    public AddHeaderFooters createAddHeaderFooters() {
+        return new AddHeaderFooters();
+    }
+
+    /**
+     * Create an instance of {@link ReadMessagesResponse }
+     * 
+     */
+    public ReadMessagesResponse createReadMessagesResponse() {
+        return new ReadMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddSMSDeliveries }
+     * 
+     */
+    public AddSMSDeliveries createAddSMSDeliveries() {
+        return new AddSMSDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link UpdateDeliveryGroupResponse }
+     * 
+     */
+    public UpdateDeliveryGroupResponse createUpdateDeliveryGroupResponse() {
+        return new UpdateDeliveryGroupResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteDeliveriesResponse }
+     * 
+     */
+    public DeleteDeliveriesResponse createDeleteDeliveriesResponse() {
+        return new DeleteDeliveriesResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadHeaderFootersResponse }
+     * 
+     */
+    public ReadHeaderFootersResponse createReadHeaderFootersResponse() {
+        return new ReadHeaderFootersResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteFromDeliveryGroupResponse }
+     * 
+     */
+    public DeleteFromDeliveryGroupResponse createDeleteFromDeliveryGroupResponse() {
+        return new DeleteFromDeliveryGroupResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadDeliveriesResponse }
+     * 
+     */
+    public ReadDeliveriesResponse createReadDeliveriesResponse() {
+        return new ReadDeliveriesResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadSMSKeywords }
+     * 
+     */
+    public ReadSMSKeywords createReadSMSKeywords() {
+        return new ReadSMSKeywords();
+    }
+
+    /**
+     * Create an instance of {@link DeleteMessageFoldersResponse }
+     * 
+     */
+    public DeleteMessageFoldersResponse createDeleteMessageFoldersResponse() {
+        return new DeleteMessageFoldersResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddFieldsResponse }
+     * 
+     */
+    public AddFieldsResponse createAddFieldsResponse() {
+        return new AddFieldsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddMessagesResponse }
+     * 
+     */
+    public AddMessagesResponse createAddMessagesResponse() {
+        return new AddMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadMessageRulesResponse }
+     * 
+     */
+    public ReadMessageRulesResponse createReadMessageRulesResponse() {
+        return new ReadMessageRulesResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateMessageRules }
+     * 
+     */
+    public UpdateMessageRules createUpdateMessageRules() {
+        return new UpdateMessageRules();
+    }
+
+    /**
+     * Create an instance of {@link DeleteContentTags }
+     * 
+     */
+    public DeleteContentTags createDeleteContentTags() {
+        return new DeleteContentTags();
+    }
+
+    /**
+     * Create an instance of {@link ReadSMSDeliveriesResponse }
+     * 
+     */
+    public ReadSMSDeliveriesResponse createReadSMSDeliveriesResponse() {
+        return new ReadSMSDeliveriesResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateSMSDeliveriesResponse }
+     * 
+     */
+    public UpdateSMSDeliveriesResponse createUpdateSMSDeliveriesResponse() {
+        return new UpdateSMSDeliveriesResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadActivities }
+     * 
+     */
+    public ReadActivities createReadActivities() {
+        return new ReadActivities();
+    }
+
+    /**
+     * Create an instance of {@link ReadConversionsResponse }
+     * 
+     */
+    public ReadConversionsResponse createReadConversionsResponse() {
+        return new ReadConversionsResponse();
+    }
+
+    /**
+     * Create an instance of {@link SessionHeader }
+     * 
+     */
+    public SessionHeader createSessionHeader() {
+        return new SessionHeader();
+    }
+
+    /**
+     * Create an instance of {@link AddContactEventResponse }
+     * 
+     */
+    public AddContactEventResponse createAddContactEventResponse() {
+        return new AddContactEventResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddSMSDeliveriesResponse }
+     * 
+     */
+    public AddSMSDeliveriesResponse createAddSMSDeliveriesResponse() {
+        return new AddSMSDeliveriesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddToSMSKeywordResponse }
+     * 
+     */
+    public AddToSMSKeywordResponse createAddToSMSKeywordResponse() {
+        return new AddToSMSKeywordResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddAccounts }
+     * 
+     */
+    public AddAccounts createAddAccounts() {
+        return new AddAccounts();
+    }
+
+    /**
+     * Create an instance of {@link UpdateSMSMessagesResponse }
+     * 
+     */
+    public UpdateSMSMessagesResponse createUpdateSMSMessagesResponse() {
+        return new UpdateSMSMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddOrUpdateContacts }
+     * 
+     */
+    public AddOrUpdateContacts createAddOrUpdateContacts() {
+        return new AddOrUpdateContacts();
+    }
+
+    /**
+     * Create an instance of {@link DeleteSMSMessages }
+     * 
+     */
+    public DeleteSMSMessages createDeleteSMSMessages() {
+        return new DeleteSMSMessages();
+    }
+
+    /**
+     * Create an instance of {@link AddLists }
+     * 
+     */
+    public AddLists createAddLists() {
+        return new AddLists();
+    }
+
+    /**
+     * Create an instance of {@link ReadUnsubscribes }
+     * 
+     */
+    public ReadUnsubscribes createReadUnsubscribes() {
+        return new ReadUnsubscribes();
+    }
+
+    /**
+     * Create an instance of {@link AddOrUpdateOrders }
+     * 
+     */
+    public AddOrUpdateOrders createAddOrUpdateOrders() {
+        return new AddOrUpdateOrders();
+    }
+
+    /**
+     * Create an instance of {@link ClearListsResponse }
+     * 
+     */
+    public ClearListsResponse createClearListsResponse() {
+        return new ClearListsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadMessages }
+     * 
+     */
+    public ReadMessages createReadMessages() {
+        return new ReadMessages();
     }
 
     /**
@@ -1717,171 +637,1099 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link DeleteMessageFolders }
+     * Create an instance of {@link DeleteFieldsResponse }
      * 
      */
-    public DeleteMessageFolders createDeleteMessageFolders() {
-        return new DeleteMessageFolders();
+    public DeleteFieldsResponse createDeleteFieldsResponse() {
+        return new DeleteFieldsResponse();
     }
 
     /**
-     * Create an instance of {@link WriteResult }
+     * Create an instance of {@link UpdateFieldsResponse }
      * 
      */
-    public WriteResult createWriteResult() {
-        return new WriteResult();
+    public UpdateFieldsResponse createUpdateFieldsResponse() {
+        return new UpdateFieldsResponse();
     }
 
     /**
-     * Create an instance of {@link MessageFieldObject }
+     * Create an instance of {@link AddSMSMessages }
      * 
      */
-    public MessageFieldObject createMessageFieldObject() {
-        return new MessageFieldObject();
+    public AddSMSMessages createAddSMSMessages() {
+        return new AddSMSMessages();
     }
 
     /**
-     * Create an instance of {@link AccountFilter }
+     * Create an instance of {@link DeleteDeliveryGroup }
      * 
      */
-    public AccountFilter createAccountFilter() {
-        return new AccountFilter();
+    public DeleteDeliveryGroup createDeleteDeliveryGroup() {
+        return new DeleteDeliveryGroup();
     }
 
     /**
-     * Create an instance of {@link FieldsFilter }
+     * Create an instance of {@link UpdateAccountsResponse }
      * 
      */
-    public FieldsFilter createFieldsFilter() {
-        return new FieldsFilter();
+    public UpdateAccountsResponse createUpdateAccountsResponse() {
+        return new UpdateAccountsResponse();
     }
 
     /**
-     * Create an instance of {@link FieldOptionObject }
+     * Create an instance of {@link AddContactsResponse }
      * 
      */
-    public FieldOptionObject createFieldOptionObject() {
-        return new FieldOptionObject();
+    public AddContactsResponse createAddContactsResponse() {
+        return new AddContactsResponse();
     }
 
     /**
-     * Create an instance of {@link DeliveryGroupFilter }
+     * Create an instance of {@link Login }
      * 
      */
-    public DeliveryGroupFilter createDeliveryGroupFilter() {
-        return new DeliveryGroupFilter();
+    public Login createLogin() {
+        return new Login();
     }
 
     /**
-     * Create an instance of {@link RecentInboundActivitySearchRequest }
+     * Create an instance of {@link AddUpdateOrder }
      * 
      */
-    public RecentInboundActivitySearchRequest createRecentInboundActivitySearchRequest() {
-        return new RecentInboundActivitySearchRequest();
+    public AddUpdateOrder createAddUpdateOrder() {
+        return new AddUpdateOrder();
     }
 
     /**
-     * Create an instance of {@link MessageRuleFilter }
+     * Create an instance of {@link AddDeliveriesResponse }
      * 
      */
-    public MessageRuleFilter createMessageRuleFilter() {
-        return new MessageRuleFilter();
+    public AddDeliveriesResponse createAddDeliveriesResponse() {
+        return new AddDeliveriesResponse();
     }
 
     /**
-     * Create an instance of {@link ApiTokenObject }
+     * Create an instance of {@link ReadContactsResponse }
      * 
      */
-    public ApiTokenObject createApiTokenObject() {
-        return new ApiTokenObject();
+    public ReadContactsResponse createReadContactsResponse() {
+        return new ReadContactsResponse();
     }
 
     /**
-     * Create an instance of {@link ContactFilter }
+     * Create an instance of {@link AddLoginsResponse }
      * 
      */
-    public ContactFilter createContactFilter() {
-        return new ContactFilter();
+    public AddLoginsResponse createAddLoginsResponse() {
+        return new AddLoginsResponse();
     }
 
     /**
-     * Create an instance of {@link ApiTokenFilter }
+     * Create an instance of {@link AddWorkflowsResponse }
      * 
      */
-    public ApiTokenFilter createApiTokenFilter() {
-        return new ApiTokenFilter();
+    public AddWorkflowsResponse createAddWorkflowsResponse() {
+        return new AddWorkflowsResponse();
     }
 
     /**
-     * Create an instance of {@link MessageObject }
+     * Create an instance of {@link AddDeliveryGroup }
      * 
      */
-    public MessageObject createMessageObject() {
-        return new MessageObject();
+    public AddDeliveryGroup createAddDeliveryGroup() {
+        return new AddDeliveryGroup();
     }
 
     /**
-     * Create an instance of {@link SmsKeywordObject }
+     * Create an instance of {@link ReadWorkflowsResponse }
      * 
      */
-    public SmsKeywordObject createSmsKeywordObject() {
-        return new SmsKeywordObject();
+    public ReadWorkflowsResponse createReadWorkflowsResponse() {
+        return new ReadWorkflowsResponse();
     }
 
     /**
-     * Create an instance of {@link MailListObject }
+     * Create an instance of {@link ReadWebforms }
      * 
      */
-    public MailListObject createMailListObject() {
-        return new MailListObject();
+    public ReadWebforms createReadWebforms() {
+        return new ReadWebforms();
     }
 
     /**
-     * Create an instance of {@link MessageFilter }
+     * Create an instance of {@link AddConversionResponse }
      * 
      */
-    public MessageFilter createMessageFilter() {
-        return new MessageFilter();
+    public AddConversionResponse createAddConversionResponse() {
+        return new AddConversionResponse();
     }
 
     /**
-     * Create an instance of {@link MailListFilter }
+     * Create an instance of {@link AddDeliveryGroupResponse }
      * 
      */
-    public MailListFilter createMailListFilter() {
-        return new MailListFilter();
+    public AddDeliveryGroupResponse createAddDeliveryGroupResponse() {
+        return new AddDeliveryGroupResponse();
     }
 
     /**
-     * Create an instance of {@link SmsDeliveryContactsObject }
+     * Create an instance of {@link DeleteListsResponse }
      * 
      */
-    public SmsDeliveryContactsObject createSmsDeliveryContactsObject() {
-        return new SmsDeliveryContactsObject();
+    public DeleteListsResponse createDeleteListsResponse() {
+        return new DeleteListsResponse();
     }
 
     /**
-     * Create an instance of {@link BounceFilter }
+     * Create an instance of {@link UpdateSMSMessages }
      * 
      */
-    public BounceFilter createBounceFilter() {
-        return new BounceFilter();
+    public UpdateSMSMessages createUpdateSMSMessages() {
+        return new UpdateSMSMessages();
     }
 
     /**
-     * Create an instance of {@link MessageFolderFilter }
+     * Create an instance of {@link DeleteLoginsResponse }
      * 
      */
-    public MessageFolderFilter createMessageFolderFilter() {
-        return new MessageFolderFilter();
+    public DeleteLoginsResponse createDeleteLoginsResponse() {
+        return new DeleteLoginsResponse();
     }
 
     /**
-     * Create an instance of {@link StringValue }
+     * Create an instance of {@link AddAccountsResponse }
      * 
      */
-    public StringValue createStringValue() {
-        return new StringValue();
+    public AddAccountsResponse createAddAccountsResponse() {
+        return new AddAccountsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddHeaderFootersResponse }
+     * 
+     */
+    public AddHeaderFootersResponse createAddHeaderFootersResponse() {
+        return new AddHeaderFootersResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddListsResponse }
+     * 
+     */
+    public AddListsResponse createAddListsResponse() {
+        return new AddListsResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateMessages }
+     * 
+     */
+    public UpdateMessages createUpdateMessages() {
+        return new UpdateMessages();
+    }
+
+    /**
+     * Create an instance of {@link RemoveFromSMSKeyword }
+     * 
+     */
+    public RemoveFromSMSKeyword createRemoveFromSMSKeyword() {
+        return new RemoveFromSMSKeyword();
+    }
+
+    /**
+     * Create an instance of {@link ReadBounces }
+     * 
+     */
+    public ReadBounces createReadBounces() {
+        return new ReadBounces();
+    }
+
+    /**
+     * Create an instance of {@link AddConversion }
+     * 
+     */
+    public AddConversion createAddConversion() {
+        return new AddConversion();
+    }
+
+    /**
+     * Create an instance of {@link ReadMessageFolders }
+     * 
+     */
+    public ReadMessageFolders createReadMessageFolders() {
+        return new ReadMessageFolders();
+    }
+
+    /**
+     * Create an instance of {@link AddMessages }
+     * 
+     */
+    public AddMessages createAddMessages() {
+        return new AddMessages();
+    }
+
+    /**
+     * Create an instance of {@link DeleteApiTokensResponse }
+     * 
+     */
+    public DeleteApiTokensResponse createDeleteApiTokensResponse() {
+        return new DeleteApiTokensResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadSMSMessagesResponse }
+     * 
+     */
+    public ReadSMSMessagesResponse createReadSMSMessagesResponse() {
+        return new ReadSMSMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteSMSMessagesResponse }
+     * 
+     */
+    public DeleteSMSMessagesResponse createDeleteSMSMessagesResponse() {
+        return new DeleteSMSMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddMessageFoldersResponse }
+     * 
+     */
+    public AddMessageFoldersResponse createAddMessageFoldersResponse() {
+        return new AddMessageFoldersResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateContentTags }
+     * 
+     */
+    public UpdateContentTags createUpdateContentTags() {
+        return new UpdateContentTags();
+    }
+
+    /**
+     * Create an instance of {@link AddDeliveries }
+     * 
+     */
+    public AddDeliveries createAddDeliveries() {
+        return new AddDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link DeleteHeaderFooters }
+     * 
+     */
+    public DeleteHeaderFooters createDeleteHeaderFooters() {
+        return new DeleteHeaderFooters();
+    }
+
+    /**
+     * Create an instance of {@link UpdateMessageRulesResponse }
+     * 
+     */
+    public UpdateMessageRulesResponse createUpdateMessageRulesResponse() {
+        return new UpdateMessageRulesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddUpdateOrderResponse }
+     * 
+     */
+    public AddUpdateOrderResponse createAddUpdateOrderResponse() {
+        return new AddUpdateOrderResponse();
+    }
+
+    /**
+     * Create an instance of {@link ApiException }
+     * 
+     */
+    public ApiException createApiException() {
+        return new ApiException();
+    }
+
+    /**
+     * Create an instance of {@link ReadRecentOutboundActivitiesResponse }
+     * 
+     */
+    public ReadRecentOutboundActivitiesResponse createReadRecentOutboundActivitiesResponse() {
+        return new ReadRecentOutboundActivitiesResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateDeliveries }
+     * 
+     */
+    public UpdateDeliveries createUpdateDeliveries() {
+        return new UpdateDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link DeleteDeliveryGroupResponse }
+     * 
+     */
+    public DeleteDeliveryGroupResponse createDeleteDeliveryGroupResponse() {
+        return new DeleteDeliveryGroupResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddFields }
+     * 
+     */
+    public AddFields createAddFields() {
+        return new AddFields();
+    }
+
+    /**
+     * Create an instance of {@link UpdateSMSKeywords }
+     * 
+     */
+    public UpdateSMSKeywords createUpdateSMSKeywords() {
+        return new UpdateSMSKeywords();
+    }
+
+    /**
+     * Create an instance of {@link AddToDeliveryGroup }
+     * 
+     */
+    public AddToDeliveryGroup createAddToDeliveryGroup() {
+        return new AddToDeliveryGroup();
+    }
+
+    /**
+     * Create an instance of {@link UpdateLists }
+     * 
+     */
+    public UpdateLists createUpdateLists() {
+        return new UpdateLists();
+    }
+
+    /**
+     * Create an instance of {@link DeleteAccounts }
+     * 
+     */
+    public DeleteAccounts createDeleteAccounts() {
+        return new DeleteAccounts();
+    }
+
+    /**
+     * Create an instance of {@link ReadMessageFoldersResponse }
+     * 
+     */
+    public ReadMessageFoldersResponse createReadMessageFoldersResponse() {
+        return new ReadMessageFoldersResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddContactsToWorkflowResponse }
+     * 
+     */
+    public AddContactsToWorkflowResponse createAddContactsToWorkflowResponse() {
+        return new AddContactsToWorkflowResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddOrUpdateOrdersResponse }
+     * 
+     */
+    public AddOrUpdateOrdersResponse createAddOrUpdateOrdersResponse() {
+        return new AddOrUpdateOrdersResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadAccountsResponse }
+     * 
+     */
+    public ReadAccountsResponse createReadAccountsResponse() {
+        return new ReadAccountsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadLogins }
+     * 
+     */
+    public ReadLogins createReadLogins() {
+        return new ReadLogins();
+    }
+
+    /**
+     * Create an instance of {@link ReadDeliveryRecipients }
+     * 
+     */
+    public ReadDeliveryRecipients createReadDeliveryRecipients() {
+        return new ReadDeliveryRecipients();
+    }
+
+    /**
+     * Create an instance of {@link AddSMSMessagesResponse }
+     * 
+     */
+    public AddSMSMessagesResponse createAddSMSMessagesResponse() {
+        return new AddSMSMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteSMSKeywords }
+     * 
+     */
+    public DeleteSMSKeywords createDeleteSMSKeywords() {
+        return new DeleteSMSKeywords();
+    }
+
+    /**
+     * Create an instance of {@link AddSMSKeywordsResponse }
+     * 
+     */
+    public AddSMSKeywordsResponse createAddSMSKeywordsResponse() {
+        return new AddSMSKeywordsResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateDeliveryGroup }
+     * 
+     */
+    public UpdateDeliveryGroup createUpdateDeliveryGroup() {
+        return new UpdateDeliveryGroup();
+    }
+
+    /**
+     * Create an instance of {@link ReadDeliveryRecipientsResponse }
+     * 
+     */
+    public ReadDeliveryRecipientsResponse createReadDeliveryRecipientsResponse() {
+        return new ReadDeliveryRecipientsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadActivitiesResponse }
+     * 
+     */
+    public ReadActivitiesResponse createReadActivitiesResponse() {
+        return new ReadActivitiesResponse();
+    }
+
+    /**
+     * Create an instance of {@link LoginResponse }
+     * 
+     */
+    public LoginResponse createLoginResponse() {
+        return new LoginResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddToListResponse }
+     * 
+     */
+    public AddToListResponse createAddToListResponse() {
+        return new AddToListResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteContentTagsResponse }
+     * 
+     */
+    public DeleteContentTagsResponse createDeleteContentTagsResponse() {
+        return new DeleteContentTagsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadBouncesResponse }
+     * 
+     */
+    public ReadBouncesResponse createReadBouncesResponse() {
+        return new ReadBouncesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddOrUpdateDeliveryGroupResponse }
+     * 
+     */
+    public AddOrUpdateDeliveryGroupResponse createAddOrUpdateDeliveryGroupResponse() {
+        return new AddOrUpdateDeliveryGroupResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteFields }
+     * 
+     */
+    public DeleteFields createDeleteFields() {
+        return new DeleteFields();
+    }
+
+    /**
+     * Create an instance of {@link AddApiTokensResponse }
+     * 
+     */
+    public AddApiTokensResponse createAddApiTokensResponse() {
+        return new AddApiTokensResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteAccountsResponse }
+     * 
+     */
+    public DeleteAccountsResponse createDeleteAccountsResponse() {
+        return new DeleteAccountsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddMessageRulesResponse }
+     * 
+     */
+    public AddMessageRulesResponse createAddMessageRulesResponse() {
+        return new AddMessageRulesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddContentTagsResponse }
+     * 
+     */
+    public AddContentTagsResponse createAddContentTagsResponse() {
+        return new AddContentTagsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadConversions }
+     * 
+     */
+    public ReadConversions createReadConversions() {
+        return new ReadConversions();
+    }
+
+    /**
+     * Create an instance of {@link ReadFields }
+     * 
+     */
+    public ReadFields createReadFields() {
+        return new ReadFields();
+    }
+
+    /**
+     * Create an instance of {@link ReadSMSMessages }
+     * 
+     */
+    public ReadSMSMessages createReadSMSMessages() {
+        return new ReadSMSMessages();
+    }
+
+    /**
+     * Create an instance of {@link UpdateAccounts }
+     * 
+     */
+    public UpdateAccounts createUpdateAccounts() {
+        return new UpdateAccounts();
+    }
+
+    /**
+     * Create an instance of {@link DeleteSMSKeywordsResponse }
+     * 
+     */
+    public DeleteSMSKeywordsResponse createDeleteSMSKeywordsResponse() {
+        return new DeleteSMSKeywordsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddOrUpdateContactsResponse }
+     * 
+     */
+    public AddOrUpdateContactsResponse createAddOrUpdateContactsResponse() {
+        return new AddOrUpdateContactsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadFieldsResponse }
+     * 
+     */
+    public ReadFieldsResponse createReadFieldsResponse() {
+        return new ReadFieldsResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteLists }
+     * 
+     */
+    public DeleteLists createDeleteLists() {
+        return new DeleteLists();
+    }
+
+    /**
+     * Create an instance of {@link DeleteSMSDeliveries }
+     * 
+     */
+    public DeleteSMSDeliveries createDeleteSMSDeliveries() {
+        return new DeleteSMSDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link DeleteLogins }
+     * 
+     */
+    public DeleteLogins createDeleteLogins() {
+        return new DeleteLogins();
+    }
+
+    /**
+     * Create an instance of {@link ReadHeaderFooters }
+     * 
+     */
+    public ReadHeaderFooters createReadHeaderFooters() {
+        return new ReadHeaderFooters();
+    }
+
+    /**
+     * Create an instance of {@link UpdateMessageFolders }
+     * 
+     */
+    public UpdateMessageFolders createUpdateMessageFolders() {
+        return new UpdateMessageFolders();
+    }
+
+    /**
+     * Create an instance of {@link ReadAccounts }
+     * 
+     */
+    public ReadAccounts createReadAccounts() {
+        return new ReadAccounts();
+    }
+
+    /**
+     * Create an instance of {@link RemoveFromSMSKeywordResponse }
+     * 
+     */
+    public RemoveFromSMSKeywordResponse createRemoveFromSMSKeywordResponse() {
+        return new RemoveFromSMSKeywordResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadRecentInboundActivities }
+     * 
+     */
+    public ReadRecentInboundActivities createReadRecentInboundActivities() {
+        return new ReadRecentInboundActivities();
+    }
+
+    /**
+     * Create an instance of {@link DeleteMessageRules }
+     * 
+     */
+    public DeleteMessageRules createDeleteMessageRules() {
+        return new DeleteMessageRules();
+    }
+
+    /**
+     * Create an instance of {@link ReadSMSDeliveries }
+     * 
+     */
+    public ReadSMSDeliveries createReadSMSDeliveries() {
+        return new ReadSMSDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link DeleteMessagesResponse }
+     * 
+     */
+    public DeleteMessagesResponse createDeleteMessagesResponse() {
+        return new DeleteMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteOrdersResponse }
+     * 
+     */
+    public DeleteOrdersResponse createDeleteOrdersResponse() {
+        return new DeleteOrdersResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateFields }
+     * 
+     */
+    public UpdateFields createUpdateFields() {
+        return new UpdateFields();
+    }
+
+    /**
+     * Create an instance of {@link DeleteFromDeliveryGroup }
+     * 
+     */
+    public DeleteFromDeliveryGroup createDeleteFromDeliveryGroup() {
+        return new DeleteFromDeliveryGroup();
+    }
+
+    /**
+     * Create an instance of {@link ReadContentTags }
+     * 
+     */
+    public ReadContentTags createReadContentTags() {
+        return new ReadContentTags();
+    }
+
+    /**
+     * Create an instance of {@link DeleteApiTokens }
+     * 
+     */
+    public DeleteApiTokens createDeleteApiTokens() {
+        return new DeleteApiTokens();
+    }
+
+    /**
+     * Create an instance of {@link DeleteOrders }
+     * 
+     */
+    public DeleteOrders createDeleteOrders() {
+        return new DeleteOrders();
+    }
+
+    /**
+     * Create an instance of {@link ReadMessageRules }
+     * 
+     */
+    public ReadMessageRules createReadMessageRules() {
+        return new ReadMessageRules();
+    }
+
+    /**
+     * Create an instance of {@link UpdateMessageFoldersResponse }
+     * 
+     */
+    public UpdateMessageFoldersResponse createUpdateMessageFoldersResponse() {
+        return new UpdateMessageFoldersResponse();
+    }
+
+    /**
+     * Create an instance of {@link RemoveFromList }
+     * 
+     */
+    public RemoveFromList createRemoveFromList() {
+        return new RemoveFromList();
+    }
+
+    /**
+     * Create an instance of {@link AddSMSKeywords }
+     * 
+     */
+    public AddSMSKeywords createAddSMSKeywords() {
+        return new AddSMSKeywords();
+    }
+
+    /**
+     * Create an instance of {@link AddToList }
+     * 
+     */
+    public AddToList createAddToList() {
+        return new AddToList();
+    }
+
+    /**
+     * Create an instance of {@link DeleteContacts }
+     * 
+     */
+    public DeleteContacts createDeleteContacts() {
+        return new DeleteContacts();
+    }
+
+    /**
+     * Create an instance of {@link DeleteSMSDeliveriesResponse }
+     * 
+     */
+    public DeleteSMSDeliveriesResponse createDeleteSMSDeliveriesResponse() {
+        return new DeleteSMSDeliveriesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddWorkflows }
+     * 
+     */
+    public AddWorkflows createAddWorkflows() {
+        return new AddWorkflows();
+    }
+
+    /**
+     * Create an instance of {@link DeleteWorkflows }
+     * 
+     */
+    public DeleteWorkflows createDeleteWorkflows() {
+        return new DeleteWorkflows();
+    }
+
+    /**
+     * Create an instance of {@link ReadUnsubscribesResponse }
+     * 
+     */
+    public ReadUnsubscribesResponse createReadUnsubscribesResponse() {
+        return new ReadUnsubscribesResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddContactsToWorkflow }
+     * 
+     */
+    public AddContactsToWorkflow createAddContactsToWorkflow() {
+        return new AddContactsToWorkflow();
+    }
+
+    /**
+     * Create an instance of {@link DeleteHeaderFootersResponse }
+     * 
+     */
+    public DeleteHeaderFootersResponse createDeleteHeaderFootersResponse() {
+        return new DeleteHeaderFootersResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadRecentInboundActivitiesResponse }
+     * 
+     */
+    public ReadRecentInboundActivitiesResponse createReadRecentInboundActivitiesResponse() {
+        return new ReadRecentInboundActivitiesResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadApiTokensResponse }
+     * 
+     */
+    public ReadApiTokensResponse createReadApiTokensResponse() {
+        return new ReadApiTokensResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateHeaderFooters }
+     * 
+     */
+    public UpdateHeaderFooters createUpdateHeaderFooters() {
+        return new UpdateHeaderFooters();
+    }
+
+    /**
+     * Create an instance of {@link UpdateContactsResponse }
+     * 
+     */
+    public UpdateContactsResponse createUpdateContactsResponse() {
+        return new UpdateContactsResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateSMSDeliveries }
+     * 
+     */
+    public UpdateSMSDeliveries createUpdateSMSDeliveries() {
+        return new UpdateSMSDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link ReadApiTokens }
+     * 
+     */
+    public ReadApiTokens createReadApiTokens() {
+        return new ReadApiTokens();
+    }
+
+    /**
+     * Create an instance of {@link DeleteWorkflowsResponse }
+     * 
+     */
+    public DeleteWorkflowsResponse createDeleteWorkflowsResponse() {
+        return new DeleteWorkflowsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadDeliveries }
+     * 
+     */
+    public ReadDeliveries createReadDeliveries() {
+        return new ReadDeliveries();
+    }
+
+    /**
+     * Create an instance of {@link ReadContentTagsResponse }
+     * 
+     */
+    public ReadContentTagsResponse createReadContentTagsResponse() {
+        return new ReadContentTagsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddLogins }
+     * 
+     */
+    public AddLogins createAddLogins() {
+        return new AddLogins();
+    }
+
+    /**
+     * Create an instance of {@link ReadContacts }
+     * 
+     */
+    public ReadContacts createReadContacts() {
+        return new ReadContacts();
+    }
+
+    /**
+     * Create an instance of {@link UpdateContentTagsResponse }
+     * 
+     */
+    public UpdateContentTagsResponse createUpdateContentTagsResponse() {
+        return new UpdateContentTagsResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateLogins }
+     * 
+     */
+    public UpdateLogins createUpdateLogins() {
+        return new UpdateLogins();
+    }
+
+    /**
+     * Create an instance of {@link UpdateLoginsResponse }
+     * 
+     */
+    public UpdateLoginsResponse createUpdateLoginsResponse() {
+        return new UpdateLoginsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddContactEvent }
+     * 
+     */
+    public AddContactEvent createAddContactEvent() {
+        return new AddContactEvent();
+    }
+
+    /**
+     * Create an instance of {@link ReadDeliveryGroupsResponse }
+     * 
+     */
+    public ReadDeliveryGroupsResponse createReadDeliveryGroupsResponse() {
+        return new ReadDeliveryGroupsResponse();
+    }
+
+    /**
+     * Create an instance of {@link AddToDeliveryGroupResponse }
+     * 
+     */
+    public AddToDeliveryGroupResponse createAddToDeliveryGroupResponse() {
+        return new AddToDeliveryGroupResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadRecentOutboundActivities }
+     * 
+     */
+    public ReadRecentOutboundActivities createReadRecentOutboundActivities() {
+        return new ReadRecentOutboundActivities();
+    }
+
+    /**
+     * Create an instance of {@link UpdateApiTokens }
+     * 
+     */
+    public UpdateApiTokens createUpdateApiTokens() {
+        return new UpdateApiTokens();
+    }
+
+    /**
+     * Create an instance of {@link UpdateMessagesResponse }
+     * 
+     */
+    public UpdateMessagesResponse createUpdateMessagesResponse() {
+        return new UpdateMessagesResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadWebformsResponse }
+     * 
+     */
+    public ReadWebformsResponse createReadWebformsResponse() {
+        return new ReadWebformsResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateHeaderFootersResponse }
+     * 
+     */
+    public UpdateHeaderFootersResponse createUpdateHeaderFootersResponse() {
+        return new UpdateHeaderFootersResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateWorkflows }
+     * 
+     */
+    public UpdateWorkflows createUpdateWorkflows() {
+        return new UpdateWorkflows();
+    }
+
+    /**
+     * Create an instance of {@link AddOrUpdateDeliveryGroup }
+     * 
+     */
+    public AddOrUpdateDeliveryGroup createAddOrUpdateDeliveryGroup() {
+        return new AddOrUpdateDeliveryGroup();
+    }
+
+    /**
+     * Create an instance of {@link RemoveFromListResponse }
+     * 
+     */
+    public RemoveFromListResponse createRemoveFromListResponse() {
+        return new RemoveFromListResponse();
+    }
+
+    /**
+     * Create an instance of {@link UpdateSMSKeywordsResponse }
+     * 
+     */
+    public UpdateSMSKeywordsResponse createUpdateSMSKeywordsResponse() {
+        return new UpdateSMSKeywordsResponse();
+    }
+
+    /**
+     * Create an instance of {@link DeleteContactsResponse }
+     * 
+     */
+    public DeleteContactsResponse createDeleteContactsResponse() {
+        return new DeleteContactsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ReadSegments }
+     * 
+     */
+    public ReadSegments createReadSegments() {
+        return new ReadSegments();
+    }
+
+    /**
+     * Create an instance of {@link ReadDeliveryGroups }
+     * 
+     */
+    public ReadDeliveryGroups createReadDeliveryGroups() {
+        return new ReadDeliveryGroups();
+    }
+
+    /**
+     * Create an instance of {@link AddApiTokens }
+     * 
+     */
+    public AddApiTokens createAddApiTokens() {
+        return new AddApiTokens();
+    }
+
+    /**
+     * Create an instance of {@link UpdateListsResponse }
+     * 
+     */
+    public UpdateListsResponse createUpdateListsResponse() {
+        return new UpdateListsResponse();
+    }
+
+    /**
+     * Create an instance of {@link ActivityObject }
+     * 
+     */
+    public ActivityObject createActivityObject() {
+        return new ActivityObject();
     }
 
     /**
@@ -1893,227 +1741,19 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link DeliveryGroupObject }
+     * Create an instance of {@link MessageFolderFilter }
      * 
      */
-    public DeliveryGroupObject createDeliveryGroupObject() {
-        return new DeliveryGroupObject();
+    public MessageFolderFilter createMessageFolderFilter() {
+        return new MessageFolderFilter();
     }
 
     /**
-     * Create an instance of {@link SegmentRuleObject }
+     * Create an instance of {@link WorkflowObject }
      * 
      */
-    public SegmentRuleObject createSegmentRuleObject() {
-        return new SegmentRuleObject();
-    }
-
-    /**
-     * Create an instance of {@link DeliveryRecipientStatObject }
-     * 
-     */
-    public DeliveryRecipientStatObject createDeliveryRecipientStatObject() {
-        return new DeliveryRecipientStatObject();
-    }
-
-    /**
-     * Create an instance of {@link SegmentObject }
-     * 
-     */
-    public SegmentObject createSegmentObject() {
-        return new SegmentObject();
-    }
-
-    /**
-     * Create an instance of {@link ProductObject }
-     * 
-     */
-    public ProductObject createProductObject() {
-        return new ProductObject();
-    }
-
-    /**
-     * Create an instance of {@link LoginObject }
-     * 
-     */
-    public LoginObject createLoginObject() {
-        return new LoginObject();
-    }
-
-    /**
-     * Create an instance of {@link ResultItem }
-     * 
-     */
-    public ResultItem createResultItem() {
-        return new ResultItem();
-    }
-
-    /**
-     * Create an instance of {@link HeaderFooterObject }
-     * 
-     */
-    public HeaderFooterObject createHeaderFooterObject() {
-        return new HeaderFooterObject();
-    }
-
-    /**
-     * Create an instance of {@link SmsDeliveryFilter }
-     * 
-     */
-    public SmsDeliveryFilter createSmsDeliveryFilter() {
-        return new SmsDeliveryFilter();
-    }
-
-    /**
-     * Create an instance of {@link SegmentCriteriaObject }
-     * 
-     */
-    public SegmentCriteriaObject createSegmentCriteriaObject() {
-        return new SegmentCriteriaObject();
-    }
-
-    /**
-     * Create an instance of {@link DeliveryRecipientFilter }
-     * 
-     */
-    public DeliveryRecipientFilter createDeliveryRecipientFilter() {
-        return new DeliveryRecipientFilter();
-    }
-
-    /**
-     * Create an instance of {@link UnsubscribeObject }
-     * 
-     */
-    public UnsubscribeObject createUnsubscribeObject() {
-        return new UnsubscribeObject();
-    }
-
-    /**
-     * Create an instance of {@link BrandingSettings }
-     * 
-     */
-    public BrandingSettings createBrandingSettings() {
-        return new BrandingSettings();
-    }
-
-    /**
-     * Create an instance of {@link ContentTagFilter }
-     * 
-     */
-    public ContentTagFilter createContentTagFilter() {
-        return new ContentTagFilter();
-    }
-
-    /**
-     * Create an instance of {@link SmsMessageFieldObject }
-     * 
-     */
-    public SmsMessageFieldObject createSmsMessageFieldObject() {
-        return new SmsMessageFieldObject();
-    }
-
-    /**
-     * Create an instance of {@link SmsMessageObject }
-     * 
-     */
-    public SmsMessageObject createSmsMessageObject() {
-        return new SmsMessageObject();
-    }
-
-    /**
-     * Create an instance of {@link DeliveryFilter }
-     * 
-     */
-    public DeliveryFilter createDeliveryFilter() {
-        return new DeliveryFilter();
-    }
-
-    /**
-     * Create an instance of {@link AccountAllocations }
-     * 
-     */
-    public AccountAllocations createAccountAllocations() {
-        return new AccountAllocations();
-    }
-
-    /**
-     * Create an instance of {@link ActivityFilter }
-     * 
-     */
-    public ActivityFilter createActivityFilter() {
-        return new ActivityFilter();
-    }
-
-    /**
-     * Create an instance of {@link FormatSettings }
-     * 
-     */
-    public FormatSettings createFormatSettings() {
-        return new FormatSettings();
-    }
-
-    /**
-     * Create an instance of {@link ContactInformation }
-     * 
-     */
-    public ContactInformation createContactInformation() {
-        return new ContactInformation();
-    }
-
-    /**
-     * Create an instance of {@link RecentOutboundActivitySearchRequest }
-     * 
-     */
-    public RecentOutboundActivitySearchRequest createRecentOutboundActivitySearchRequest() {
-        return new RecentOutboundActivitySearchRequest();
-    }
-
-    /**
-     * Create an instance of {@link WebformObject }
-     * 
-     */
-    public WebformObject createWebformObject() {
-        return new WebformObject();
-    }
-
-    /**
-     * Create an instance of {@link GeneralSettings }
-     * 
-     */
-    public GeneralSettings createGeneralSettings() {
-        return new GeneralSettings();
-    }
-
-    /**
-     * Create an instance of {@link LoginFilter }
-     * 
-     */
-    public LoginFilter createLoginFilter() {
-        return new LoginFilter();
-    }
-
-    /**
-     * Create an instance of {@link SmsKeywordFilter }
-     * 
-     */
-    public SmsKeywordFilter createSmsKeywordFilter() {
-        return new SmsKeywordFilter();
-    }
-
-    /**
-     * Create an instance of {@link ContentTagObject }
-     * 
-     */
-    public ContentTagObject createContentTagObject() {
-        return new ContentTagObject();
-    }
-
-    /**
-     * Create an instance of {@link DateValue }
-     * 
-     */
-    public DateValue createDateValue() {
-        return new DateValue();
+    public WorkflowObject createWorkflowObject() {
+        return new WorkflowObject();
     }
 
     /**
@@ -2133,75 +1773,19 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link BounceObject }
+     * Create an instance of {@link RecentOutboundActivitySearchRequest }
      * 
      */
-    public BounceObject createBounceObject() {
-        return new BounceObject();
+    public RecentOutboundActivitySearchRequest createRecentOutboundActivitySearchRequest() {
+        return new RecentOutboundActivitySearchRequest();
     }
 
     /**
-     * Create an instance of {@link AccountObject }
+     * Create an instance of {@link FieldOptionObject }
      * 
      */
-    public AccountObject createAccountObject() {
-        return new AccountObject();
-    }
-
-    /**
-     * Create an instance of {@link OrderObject }
-     * 
-     */
-    public OrderObject createOrderObject() {
-        return new OrderObject();
-    }
-
-    /**
-     * Create an instance of {@link DeliveryRecipientObject }
-     * 
-     */
-    public DeliveryRecipientObject createDeliveryRecipientObject() {
-        return new DeliveryRecipientObject();
-    }
-
-    /**
-     * Create an instance of {@link ConversionObject }
-     * 
-     */
-    public ConversionObject createConversionObject() {
-        return new ConversionObject();
-    }
-
-    /**
-     * Create an instance of {@link RemailObject }
-     * 
-     */
-    public RemailObject createRemailObject() {
-        return new RemailObject();
-    }
-
-    /**
-     * Create an instance of {@link MessageRuleObject }
-     * 
-     */
-    public MessageRuleObject createMessageRuleObject() {
-        return new MessageRuleObject();
-    }
-
-    /**
-     * Create an instance of {@link MessageFolderObject }
-     * 
-     */
-    public MessageFolderObject createMessageFolderObject() {
-        return new MessageFolderObject();
-    }
-
-    /**
-     * Create an instance of {@link WorkflowObject }
-     * 
-     */
-    public WorkflowObject createWorkflowObject() {
-        return new WorkflowObject();
+    public FieldOptionObject createFieldOptionObject() {
+        return new FieldOptionObject();
     }
 
     /**
@@ -2213,6 +1797,206 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link GeneralSettings }
+     * 
+     */
+    public GeneralSettings createGeneralSettings() {
+        return new GeneralSettings();
+    }
+
+    /**
+     * Create an instance of {@link SegmentCriteriaObject }
+     * 
+     */
+    public SegmentCriteriaObject createSegmentCriteriaObject() {
+        return new SegmentCriteriaObject();
+    }
+
+    /**
+     * Create an instance of {@link MessageFilter }
+     * 
+     */
+    public MessageFilter createMessageFilter() {
+        return new MessageFilter();
+    }
+
+    /**
+     * Create an instance of {@link SmsKeywordObject }
+     * 
+     */
+    public SmsKeywordObject createSmsKeywordObject() {
+        return new SmsKeywordObject();
+    }
+
+    /**
+     * Create an instance of {@link BounceFilter }
+     * 
+     */
+    public BounceFilter createBounceFilter() {
+        return new BounceFilter();
+    }
+
+    /**
+     * Create an instance of {@link WebformObject }
+     * 
+     */
+    public WebformObject createWebformObject() {
+        return new WebformObject();
+    }
+
+    /**
+     * Create an instance of {@link DeliveryGroupObject }
+     * 
+     */
+    public DeliveryGroupObject createDeliveryGroupObject() {
+        return new DeliveryGroupObject();
+    }
+
+    /**
+     * Create an instance of {@link AccountAllocations }
+     * 
+     */
+    public AccountAllocations createAccountAllocations() {
+        return new AccountAllocations();
+    }
+
+    /**
+     * Create an instance of {@link ContactField }
+     * 
+     */
+    public ContactField createContactField() {
+        return new ContactField();
+    }
+
+    /**
+     * Create an instance of {@link LoginObject }
+     * 
+     */
+    public LoginObject createLoginObject() {
+        return new LoginObject();
+    }
+
+    /**
+     * Create an instance of {@link StringValue }
+     * 
+     */
+    public StringValue createStringValue() {
+        return new StringValue();
+    }
+
+    /**
+     * Create an instance of {@link BounceObject }
+     * 
+     */
+    public BounceObject createBounceObject() {
+        return new BounceObject();
+    }
+
+    /**
+     * Create an instance of {@link ContentTagFilter }
+     * 
+     */
+    public ContentTagFilter createContentTagFilter() {
+        return new ContentTagFilter();
+    }
+
+    /**
+     * Create an instance of {@link SmsDeliveryObject }
+     * 
+     */
+    public SmsDeliveryObject createSmsDeliveryObject() {
+        return new SmsDeliveryObject();
+    }
+
+    /**
+     * Create an instance of {@link UnsubscribeObject }
+     * 
+     */
+    public UnsubscribeObject createUnsubscribeObject() {
+        return new UnsubscribeObject();
+    }
+
+    /**
+     * Create an instance of {@link FieldsFilter }
+     * 
+     */
+    public FieldsFilter createFieldsFilter() {
+        return new FieldsFilter();
+    }
+
+    /**
+     * Create an instance of {@link SegmentRuleObject }
+     * 
+     */
+    public SegmentRuleObject createSegmentRuleObject() {
+        return new SegmentRuleObject();
+    }
+
+    /**
+     * Create an instance of {@link MessageRuleObject }
+     * 
+     */
+    public MessageRuleObject createMessageRuleObject() {
+        return new MessageRuleObject();
+    }
+
+    /**
+     * Create an instance of {@link SmsDeliveryContactsObject }
+     * 
+     */
+    public SmsDeliveryContactsObject createSmsDeliveryContactsObject() {
+        return new SmsDeliveryContactsObject();
+    }
+
+    /**
+     * Create an instance of {@link BrandingSettings }
+     * 
+     */
+    public BrandingSettings createBrandingSettings() {
+        return new BrandingSettings();
+    }
+
+    /**
+     * Create an instance of {@link MailListObject }
+     * 
+     */
+    public MailListObject createMailListObject() {
+        return new MailListObject();
+    }
+
+    /**
+     * Create an instance of {@link DateValue }
+     * 
+     */
+    public DateValue createDateValue() {
+        return new DateValue();
+    }
+
+    /**
+     * Create an instance of {@link ApiTokenObject }
+     * 
+     */
+    public ApiTokenObject createApiTokenObject() {
+        return new ApiTokenObject();
+    }
+
+    /**
+     * Create an instance of {@link MessageFolderObject }
+     * 
+     */
+    public MessageFolderObject createMessageFolderObject() {
+        return new MessageFolderObject();
+    }
+
+    /**
+     * Create an instance of {@link ConversionObject }
+     * 
+     */
+    public ConversionObject createConversionObject() {
+        return new ConversionObject();
+    }
+
+    /**
      * Create an instance of {@link WorkflowFilter }
      * 
      */
@@ -2221,11 +2005,75 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link WebformFilter }
+     * Create an instance of {@link DeliveryRecipientFilter }
      * 
      */
-    public WebformFilter createWebformFilter() {
-        return new WebformFilter();
+    public DeliveryRecipientFilter createDeliveryRecipientFilter() {
+        return new DeliveryRecipientFilter();
+    }
+
+    /**
+     * Create an instance of {@link FormatSettings }
+     * 
+     */
+    public FormatSettings createFormatSettings() {
+        return new FormatSettings();
+    }
+
+    /**
+     * Create an instance of {@link ReadOnlyContactData }
+     * 
+     */
+    public ReadOnlyContactData createReadOnlyContactData() {
+        return new ReadOnlyContactData();
+    }
+
+    /**
+     * Create an instance of {@link DeliveryFilter }
+     * 
+     */
+    public DeliveryFilter createDeliveryFilter() {
+        return new DeliveryFilter();
+    }
+
+    /**
+     * Create an instance of {@link RemailObject }
+     * 
+     */
+    public RemailObject createRemailObject() {
+        return new RemailObject();
+    }
+
+    /**
+     * Create an instance of {@link RecentActivityObject }
+     * 
+     */
+    public RecentActivityObject createRecentActivityObject() {
+        return new RecentActivityObject();
+    }
+
+    /**
+     * Create an instance of {@link DeliveryGroupFilter }
+     * 
+     */
+    public DeliveryGroupFilter createDeliveryGroupFilter() {
+        return new DeliveryGroupFilter();
+    }
+
+    /**
+     * Create an instance of {@link ResultItem }
+     * 
+     */
+    public ResultItem createResultItem() {
+        return new ResultItem();
+    }
+
+    /**
+     * Create an instance of {@link DeliveryObject }
+     * 
+     */
+    public DeliveryObject createDeliveryObject() {
+        return new DeliveryObject();
     }
 
     /**
@@ -2234,14 +2082,6 @@ public class ObjectFactory {
      */
     public DateTime createDateTime() {
         return new DateTime();
-    }
-
-    /**
-     * Create an instance of {@link HeaderFooterFilter }
-     * 
-     */
-    public HeaderFooterFilter createHeaderFooterFilter() {
-        return new HeaderFooterFilter();
     }
 
     /**
@@ -2261,6 +2101,102 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link ActivityFilter }
+     * 
+     */
+    public ActivityFilter createActivityFilter() {
+        return new ActivityFilter();
+    }
+
+    /**
+     * Create an instance of {@link ProductObject }
+     * 
+     */
+    public ProductObject createProductObject() {
+        return new ProductObject();
+    }
+
+    /**
+     * Create an instance of {@link HeaderFooterFilter }
+     * 
+     */
+    public HeaderFooterFilter createHeaderFooterFilter() {
+        return new HeaderFooterFilter();
+    }
+
+    /**
+     * Create an instance of {@link MessageFieldObject }
+     * 
+     */
+    public MessageFieldObject createMessageFieldObject() {
+        return new MessageFieldObject();
+    }
+
+    /**
+     * Create an instance of {@link AccountFilter }
+     * 
+     */
+    public AccountFilter createAccountFilter() {
+        return new AccountFilter();
+    }
+
+    /**
+     * Create an instance of {@link SmsKeywordFilter }
+     * 
+     */
+    public SmsKeywordFilter createSmsKeywordFilter() {
+        return new SmsKeywordFilter();
+    }
+
+    /**
+     * Create an instance of {@link SmsMessageFieldObject }
+     * 
+     */
+    public SmsMessageFieldObject createSmsMessageFieldObject() {
+        return new SmsMessageFieldObject();
+    }
+
+    /**
+     * Create an instance of {@link OrderObject }
+     * 
+     */
+    public OrderObject createOrderObject() {
+        return new OrderObject();
+    }
+
+    /**
+     * Create an instance of {@link WriteResult }
+     * 
+     */
+    public WriteResult createWriteResult() {
+        return new WriteResult();
+    }
+
+    /**
+     * Create an instance of {@link MessageObject }
+     * 
+     */
+    public MessageObject createMessageObject() {
+        return new MessageObject();
+    }
+
+    /**
+     * Create an instance of {@link MessageRuleFilter }
+     * 
+     */
+    public MessageRuleFilter createMessageRuleFilter() {
+        return new MessageRuleFilter();
+    }
+
+    /**
+     * Create an instance of {@link WebformFilter }
+     * 
+     */
+    public WebformFilter createWebformFilter() {
+        return new WebformFilter();
+    }
+
+    /**
      * Create an instance of {@link ContactObject }
      * 
      */
@@ -2269,600 +2205,123 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link ActivityObject }
+     * Create an instance of {@link HeaderFooterObject }
      * 
      */
-    public ActivityObject createActivityObject() {
-        return new ActivityObject();
+    public HeaderFooterObject createHeaderFooterObject() {
+        return new HeaderFooterObject();
     }
 
     /**
-     * Create an instance of {@link SmsDeliveryObject }
+     * Create an instance of {@link DeliveryRecipientObject }
      * 
      */
-    public SmsDeliveryObject createSmsDeliveryObject() {
-        return new SmsDeliveryObject();
+    public DeliveryRecipientObject createDeliveryRecipientObject() {
+        return new DeliveryRecipientObject();
     }
 
     /**
-     * Create an instance of {@link ContactField }
+     * Create an instance of {@link ContentTagObject }
      * 
      */
-    public ContactField createContactField() {
-        return new ContactField();
+    public ContentTagObject createContentTagObject() {
+        return new ContentTagObject();
     }
 
     /**
-     * Create an instance of {@link ReadOnlyContactData }
+     * Create an instance of {@link AccountObject }
      * 
      */
-    public ReadOnlyContactData createReadOnlyContactData() {
-        return new ReadOnlyContactData();
+    public AccountObject createAccountObject() {
+        return new AccountObject();
     }
 
     /**
-     * Create an instance of {@link RecentActivityObject }
+     * Create an instance of {@link ContactFilter }
      * 
      */
-    public RecentActivityObject createRecentActivityObject() {
-        return new RecentActivityObject();
+    public ContactFilter createContactFilter() {
+        return new ContactFilter();
     }
 
     /**
-     * Create an instance of {@link DeliveryObject }
+     * Create an instance of {@link ApiTokenFilter }
      * 
      */
-    public DeliveryObject createDeliveryObject() {
-        return new DeliveryObject();
+    public ApiTokenFilter createApiTokenFilter() {
+        return new ApiTokenFilter();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddConversionResponse }{@code >}}
+     * Create an instance of {@link RecentInboundActivitySearchRequest }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addConversionResponse")
-    public JAXBElement<AddConversionResponse> createAddConversionResponse(AddConversionResponse value) {
-        return new JAXBElement<AddConversionResponse>(_AddConversionResponse_QNAME, AddConversionResponse.class, null, value);
+    public RecentInboundActivitySearchRequest createRecentInboundActivitySearchRequest() {
+        return new RecentInboundActivitySearchRequest();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateContentTagsResponse }{@code >}}
+     * Create an instance of {@link SmsMessageObject }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateContentTagsResponse")
-    public JAXBElement<UpdateContentTagsResponse> createUpdateContentTagsResponse(UpdateContentTagsResponse value) {
-        return new JAXBElement<UpdateContentTagsResponse>(_UpdateContentTagsResponse_QNAME, UpdateContentTagsResponse.class, null, value);
+    public SmsMessageObject createSmsMessageObject() {
+        return new SmsMessageObject();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteApiTokensResponse }{@code >}}
+     * Create an instance of {@link LoginFilter }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteApiTokensResponse")
-    public JAXBElement<DeleteApiTokensResponse> createDeleteApiTokensResponse(DeleteApiTokensResponse value) {
-        return new JAXBElement<DeleteApiTokensResponse>(_DeleteApiTokensResponse_QNAME, DeleteApiTokensResponse.class, null, value);
+    public LoginFilter createLoginFilter() {
+        return new LoginFilter();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContactsResponse }{@code >}}
+     * Create an instance of {@link DeliveryProductObject }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContactsResponse")
-    public JAXBElement<ReadContactsResponse> createReadContactsResponse(ReadContactsResponse value) {
-        return new JAXBElement<ReadContactsResponse>(_ReadContactsResponse_QNAME, ReadContactsResponse.class, null, value);
+    public DeliveryProductObject createDeliveryProductObject() {
+        return new DeliveryProductObject();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddApiTokensResponse }{@code >}}
+     * Create an instance of {@link DeliveryRecipientStatObject }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addApiTokensResponse")
-    public JAXBElement<AddApiTokensResponse> createAddApiTokensResponse(AddApiTokensResponse value) {
-        return new JAXBElement<AddApiTokensResponse>(_AddApiTokensResponse_QNAME, AddApiTokensResponse.class, null, value);
+    public DeliveryRecipientStatObject createDeliveryRecipientStatObject() {
+        return new DeliveryRecipientStatObject();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteDeliveriesResponse }{@code >}}
+     * Create an instance of {@link SegmentObject }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteDeliveriesResponse")
-    public JAXBElement<DeleteDeliveriesResponse> createDeleteDeliveriesResponse(DeleteDeliveriesResponse value) {
-        return new JAXBElement<DeleteDeliveriesResponse>(_DeleteDeliveriesResponse_QNAME, DeleteDeliveriesResponse.class, null, value);
+    public SegmentObject createSegmentObject() {
+        return new SegmentObject();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadConversionsResponse }{@code >}}
+     * Create an instance of {@link SmsDeliveryFilter }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readConversionsResponse")
-    public JAXBElement<ReadConversionsResponse> createReadConversionsResponse(ReadConversionsResponse value) {
-        return new JAXBElement<ReadConversionsResponse>(_ReadConversionsResponse_QNAME, ReadConversionsResponse.class, null, value);
+    public SmsDeliveryFilter createSmsDeliveryFilter() {
+        return new SmsDeliveryFilter();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageFoldersResponse }{@code >}}
+     * Create an instance of {@link ContactInformation }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageFoldersResponse")
-    public JAXBElement<ReadMessageFoldersResponse> createReadMessageFoldersResponse(ReadMessageFoldersResponse value) {
-        return new JAXBElement<ReadMessageFoldersResponse>(_ReadMessageFoldersResponse_QNAME, ReadMessageFoldersResponse.class, null, value);
+    public ContactInformation createContactInformation() {
+        return new ContactInformation();
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSKeywords }{@code >}}
+     * Create an instance of {@link MailListFilter }
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSKeywords")
-    public JAXBElement<AddSMSKeywords> createAddSMSKeywords(AddSMSKeywords value) {
-        return new JAXBElement<AddSMSKeywords>(_AddSMSKeywords_QNAME, AddSMSKeywords.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadFields }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readFields")
-    public JAXBElement<ReadFields> createReadFields(ReadFields value) {
-        return new JAXBElement<ReadFields>(_ReadFields_QNAME, ReadFields.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentOutboundActivitiesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentOutboundActivitiesResponse")
-    public JAXBElement<ReadRecentOutboundActivitiesResponse> createReadRecentOutboundActivitiesResponse(ReadRecentOutboundActivitiesResponse value) {
-        return new JAXBElement<ReadRecentOutboundActivitiesResponse>(_ReadRecentOutboundActivitiesResponse_QNAME, ReadRecentOutboundActivitiesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryRecipientsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryRecipientsResponse")
-    public JAXBElement<ReadDeliveryRecipientsResponse> createReadDeliveryRecipientsResponse(ReadDeliveryRecipientsResponse value) {
-        return new JAXBElement<ReadDeliveryRecipientsResponse>(_ReadDeliveryRecipientsResponse_QNAME, ReadDeliveryRecipientsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSegments }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSegments")
-    public JAXBElement<ReadSegments> createReadSegments(ReadSegments value) {
-        return new JAXBElement<ReadSegments>(_ReadSegments_QNAME, ReadSegments.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageFolders }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageFolders")
-    public JAXBElement<UpdateMessageFolders> createUpdateMessageFolders(UpdateMessageFolders value) {
-        return new JAXBElement<UpdateMessageFolders>(_UpdateMessageFolders_QNAME, UpdateMessageFolders.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddToSMSKeywordResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToSMSKeywordResponse")
-    public JAXBElement<AddToSMSKeywordResponse> createAddToSMSKeywordResponse(AddToSMSKeywordResponse value) {
-        return new JAXBElement<AddToSMSKeywordResponse>(_AddToSMSKeywordResponse_QNAME, AddToSMSKeywordResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadActivities }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readActivities")
-    public JAXBElement<ReadActivities> createReadActivities(ReadActivities value) {
-        return new JAXBElement<ReadActivities>(_ReadActivities_QNAME, ReadActivities.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentOutboundActivities }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentOutboundActivities")
-    public JAXBElement<ReadRecentOutboundActivities> createReadRecentOutboundActivities(ReadRecentOutboundActivities value) {
-        return new JAXBElement<ReadRecentOutboundActivities>(_ReadRecentOutboundActivities_QNAME, ReadRecentOutboundActivities.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageFoldersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageFoldersResponse")
-    public JAXBElement<UpdateMessageFoldersResponse> createUpdateMessageFoldersResponse(UpdateMessageFoldersResponse value) {
-        return new JAXBElement<UpdateMessageFoldersResponse>(_UpdateMessageFoldersResponse_QNAME, UpdateMessageFoldersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateOrders }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateOrders")
-    public JAXBElement<AddOrUpdateOrders> createAddOrUpdateOrders(AddOrUpdateOrders value) {
-        return new JAXBElement<AddOrUpdateOrders>(_AddOrUpdateOrders_QNAME, AddOrUpdateOrders.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadConversions }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readConversions")
-    public JAXBElement<ReadConversions> createReadConversions(ReadConversions value) {
-        return new JAXBElement<ReadConversions>(_ReadConversions_QNAME, ReadConversions.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveryGroupResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveryGroupResponse")
-    public JAXBElement<AddDeliveryGroupResponse> createAddDeliveryGroupResponse(AddDeliveryGroupResponse value) {
-        return new JAXBElement<AddDeliveryGroupResponse>(_AddDeliveryGroupResponse_QNAME, AddDeliveryGroupResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ClearLists }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "clearLists")
-    public JAXBElement<ClearLists> createClearLists(ClearLists value) {
-        return new JAXBElement<ClearLists>(_ClearLists_QNAME, ClearLists.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddLogins }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addLogins")
-    public JAXBElement<AddLogins> createAddLogins(AddLogins value) {
-        return new JAXBElement<AddLogins>(_AddLogins_QNAME, AddLogins.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link Login }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "login")
-    public JAXBElement<Login> createLogin(Login value) {
-        return new JAXBElement<Login>(_Login_QNAME, Login.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteDeliveries }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteDeliveries")
-    public JAXBElement<DeleteDeliveries> createDeleteDeliveries(DeleteDeliveries value) {
-        return new JAXBElement<DeleteDeliveries>(_DeleteDeliveries_QNAME, DeleteDeliveries.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessages }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessages")
-    public JAXBElement<AddMessages> createAddMessages(AddMessages value) {
-        return new JAXBElement<AddMessages>(_AddMessages_QNAME, AddMessages.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadAccountsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readAccountsResponse")
-    public JAXBElement<ReadAccountsResponse> createReadAccountsResponse(ReadAccountsResponse value) {
-        return new JAXBElement<ReadAccountsResponse>(_ReadAccountsResponse_QNAME, ReadAccountsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveryGroup }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveryGroup")
-    public JAXBElement<UpdateDeliveryGroup> createUpdateDeliveryGroup(UpdateDeliveryGroup value) {
-        return new JAXBElement<UpdateDeliveryGroup>(_UpdateDeliveryGroup_QNAME, UpdateDeliveryGroup.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadApiTokensResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readApiTokensResponse")
-    public JAXBElement<ReadApiTokensResponse> createReadApiTokensResponse(ReadApiTokensResponse value) {
-        return new JAXBElement<ReadApiTokensResponse>(_ReadApiTokensResponse_QNAME, ReadApiTokensResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateLists }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateLists")
-    public JAXBElement<UpdateLists> createUpdateLists(UpdateLists value) {
-        return new JAXBElement<UpdateLists>(_UpdateLists_QNAME, UpdateLists.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSDeliveries }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSDeliveries")
-    public JAXBElement<ReadSMSDeliveries> createReadSMSDeliveries(ReadSMSDeliveries value) {
-        return new JAXBElement<ReadSMSDeliveries>(_ReadSMSDeliveries_QNAME, ReadSMSDeliveries.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteListsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteListsResponse")
-    public JAXBElement<DeleteListsResponse> createDeleteListsResponse(DeleteListsResponse value) {
-        return new JAXBElement<DeleteListsResponse>(_DeleteListsResponse_QNAME, DeleteListsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateWorkflowsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateWorkflowsResponse")
-    public JAXBElement<UpdateWorkflowsResponse> createUpdateWorkflowsResponse(UpdateWorkflowsResponse value) {
-        return new JAXBElement<UpdateWorkflowsResponse>(_UpdateWorkflowsResponse_QNAME, UpdateWorkflowsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSKeywords }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSKeywords")
-    public JAXBElement<UpdateSMSKeywords> createUpdateSMSKeywords(UpdateSMSKeywords value) {
-        return new JAXBElement<UpdateSMSKeywords>(_UpdateSMSKeywords_QNAME, UpdateSMSKeywords.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadHeaderFootersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readHeaderFootersResponse")
-    public JAXBElement<ReadHeaderFootersResponse> createReadHeaderFootersResponse(ReadHeaderFootersResponse value) {
-        return new JAXBElement<ReadHeaderFootersResponse>(_ReadHeaderFootersResponse_QNAME, ReadHeaderFootersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryRecipients }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryRecipients")
-    public JAXBElement<ReadDeliveryRecipients> createReadDeliveryRecipients(ReadDeliveryRecipients value) {
-        return new JAXBElement<ReadDeliveryRecipients>(_ReadDeliveryRecipients_QNAME, ReadDeliveryRecipients.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteDeliveryGroupResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteDeliveryGroupResponse")
-    public JAXBElement<DeleteDeliveryGroupResponse> createDeleteDeliveryGroupResponse(DeleteDeliveryGroupResponse value) {
-        return new JAXBElement<DeleteDeliveryGroupResponse>(_DeleteDeliveryGroupResponse_QNAME, DeleteDeliveryGroupResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSMessagesResponse")
-    public JAXBElement<AddSMSMessagesResponse> createAddSMSMessagesResponse(AddSMSMessagesResponse value) {
-        return new JAXBElement<AddSMSMessagesResponse>(_AddSMSMessagesResponse_QNAME, AddSMSMessagesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactEvent }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactEvent")
-    public JAXBElement<AddContactEvent> createAddContactEvent(AddContactEvent value) {
-        return new JAXBElement<AddContactEvent>(_AddContactEvent_QNAME, AddContactEvent.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSMessages }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSMessages")
-    public JAXBElement<ReadSMSMessages> createReadSMSMessages(ReadSMSMessages value) {
-        return new JAXBElement<ReadSMSMessages>(_ReadSMSMessages_QNAME, ReadSMSMessages.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageRulesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageRulesResponse")
-    public JAXBElement<DeleteMessageRulesResponse> createDeleteMessageRulesResponse(DeleteMessageRulesResponse value) {
-        return new JAXBElement<DeleteMessageRulesResponse>(_DeleteMessageRulesResponse_QNAME, DeleteMessageRulesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteLists }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteLists")
-    public JAXBElement<DeleteLists> createDeleteLists(DeleteLists value) {
-        return new JAXBElement<DeleteLists>(_DeleteLists_QNAME, DeleteLists.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddHeaderFooters }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addHeaderFooters")
-    public JAXBElement<AddHeaderFooters> createAddHeaderFooters(AddHeaderFooters value) {
-        return new JAXBElement<AddHeaderFooters>(_AddHeaderFooters_QNAME, AddHeaderFooters.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessageRulesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessageRulesResponse")
-    public JAXBElement<AddMessageRulesResponse> createAddMessageRulesResponse(AddMessageRulesResponse value) {
-        return new JAXBElement<AddMessageRulesResponse>(_AddMessageRulesResponse_QNAME, AddMessageRulesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteApiTokens }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteApiTokens")
-    public JAXBElement<DeleteApiTokens> createDeleteApiTokens(DeleteApiTokens value) {
-        return new JAXBElement<DeleteApiTokens>(_DeleteApiTokens_QNAME, DeleteApiTokens.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddUpdateOrderResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addUpdateOrderResponse")
-    public JAXBElement<AddUpdateOrderResponse> createAddUpdateOrderResponse(AddUpdateOrderResponse value) {
-        return new JAXBElement<AddUpdateOrderResponse>(_AddUpdateOrderResponse_QNAME, AddUpdateOrderResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSMessagesResponse")
-    public JAXBElement<DeleteSMSMessagesResponse> createDeleteSMSMessagesResponse(DeleteSMSMessagesResponse value) {
-        return new JAXBElement<DeleteSMSMessagesResponse>(_DeleteSMSMessagesResponse_QNAME, DeleteSMSMessagesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSDeliveriesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSDeliveriesResponse")
-    public JAXBElement<DeleteSMSDeliveriesResponse> createDeleteSMSDeliveriesResponse(DeleteSMSDeliveriesResponse value) {
-        return new JAXBElement<DeleteSMSDeliveriesResponse>(_DeleteSMSDeliveriesResponse_QNAME, DeleteSMSDeliveriesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateHeaderFootersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateHeaderFootersResponse")
-    public JAXBElement<UpdateHeaderFootersResponse> createUpdateHeaderFootersResponse(UpdateHeaderFootersResponse value) {
-        return new JAXBElement<UpdateHeaderFootersResponse>(_UpdateHeaderFootersResponse_QNAME, UpdateHeaderFootersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessages }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessages")
-    public JAXBElement<ReadMessages> createReadMessages(ReadMessages value) {
-        return new JAXBElement<ReadMessages>(_ReadMessages_QNAME, ReadMessages.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageRules }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageRules")
-    public JAXBElement<ReadMessageRules> createReadMessageRules(ReadMessageRules value) {
-        return new JAXBElement<ReadMessageRules>(_ReadMessageRules_QNAME, ReadMessageRules.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWebforms }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWebforms")
-    public JAXBElement<ReadWebforms> createReadWebforms(ReadWebforms value) {
-        return new JAXBElement<ReadWebforms>(_ReadWebforms_QNAME, ReadWebforms.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactsToWorkflow }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactsToWorkflow")
-    public JAXBElement<AddContactsToWorkflow> createAddContactsToWorkflow(AddContactsToWorkflow value) {
-        return new JAXBElement<AddContactsToWorkflow>(_AddContactsToWorkflow_QNAME, AddContactsToWorkflow.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContentTags }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContentTags")
-    public JAXBElement<ReadContentTags> createReadContentTags(ReadContentTags value) {
-        return new JAXBElement<ReadContentTags>(_ReadContentTags_QNAME, ReadContentTags.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteOrders }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteOrders")
-    public JAXBElement<DeleteOrders> createDeleteOrders(DeleteOrders value) {
-        return new JAXBElement<DeleteOrders>(_DeleteOrders_QNAME, DeleteOrders.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddHeaderFootersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addHeaderFootersResponse")
-    public JAXBElement<AddHeaderFootersResponse> createAddHeaderFootersResponse(AddHeaderFootersResponse value) {
-        return new JAXBElement<AddHeaderFootersResponse>(_AddHeaderFootersResponse_QNAME, AddHeaderFootersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteWorkflowsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteWorkflowsResponse")
-    public JAXBElement<DeleteWorkflowsResponse> createDeleteWorkflowsResponse(DeleteWorkflowsResponse value) {
-        return new JAXBElement<DeleteWorkflowsResponse>(_DeleteWorkflowsResponse_QNAME, DeleteWorkflowsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateContacts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateContacts")
-    public JAXBElement<AddOrUpdateContacts> createAddOrUpdateContacts(AddOrUpdateContacts value) {
-        return new JAXBElement<AddOrUpdateContacts>(_AddOrUpdateContacts_QNAME, AddOrUpdateContacts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessages }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessages")
-    public JAXBElement<DeleteMessages> createDeleteMessages(DeleteMessages value) {
-        return new JAXBElement<DeleteMessages>(_DeleteMessages_QNAME, DeleteMessages.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessageRules }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessageRules")
-    public JAXBElement<AddMessageRules> createAddMessageRules(AddMessageRules value) {
-        return new JAXBElement<AddMessageRules>(_AddMessageRules_QNAME, AddMessageRules.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddToListResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToListResponse")
-    public JAXBElement<AddToListResponse> createAddToListResponse(AddToListResponse value) {
-        return new JAXBElement<AddToListResponse>(_AddToListResponse_QNAME, AddToListResponse.class, null, value);
+    public MailListFilter createMailListFilter() {
+        return new MailListFilter();
     }
 
     /**
@@ -2875,294 +2334,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddListsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addListsResponse")
-    public JAXBElement<AddListsResponse> createAddListsResponse(AddListsResponse value) {
-        return new JAXBElement<AddListsResponse>(_AddListsResponse_QNAME, AddListsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadLists }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readLists")
-    public JAXBElement<ReadLists> createReadLists(ReadLists value) {
-        return new JAXBElement<ReadLists>(_ReadLists_QNAME, ReadLists.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageRulesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageRulesResponse")
-    public JAXBElement<ReadMessageRulesResponse> createReadMessageRulesResponse(ReadMessageRulesResponse value) {
-        return new JAXBElement<ReadMessageRulesResponse>(_ReadMessageRulesResponse_QNAME, ReadMessageRulesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddFieldsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addFieldsResponse")
-    public JAXBElement<AddFieldsResponse> createAddFieldsResponse(AddFieldsResponse value) {
-        return new JAXBElement<AddFieldsResponse>(_AddFieldsResponse_QNAME, AddFieldsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadLoginsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readLoginsResponse")
-    public JAXBElement<ReadLoginsResponse> createReadLoginsResponse(ReadLoginsResponse value) {
-        return new JAXBElement<ReadLoginsResponse>(_ReadLoginsResponse_QNAME, ReadLoginsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddAccounts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addAccounts")
-    public JAXBElement<AddAccounts> createAddAccounts(AddAccounts value) {
-        return new JAXBElement<AddAccounts>(_AddAccounts_QNAME, AddAccounts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSKeywords }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSKeywords")
-    public JAXBElement<ReadSMSKeywords> createReadSMSKeywords(ReadSMSKeywords value) {
-        return new JAXBElement<ReadSMSKeywords>(_ReadSMSKeywords_QNAME, ReadSMSKeywords.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromSMSKeywordResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromSMSKeywordResponse")
-    public JAXBElement<RemoveFromSMSKeywordResponse> createRemoveFromSMSKeywordResponse(RemoveFromSMSKeywordResponse value) {
-        return new JAXBElement<RemoveFromSMSKeywordResponse>(_RemoveFromSMSKeywordResponse_QNAME, RemoveFromSMSKeywordResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateFields }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateFields")
-    public JAXBElement<UpdateFields> createUpdateFields(UpdateFields value) {
-        return new JAXBElement<UpdateFields>(_UpdateFields_QNAME, UpdateFields.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessageFoldersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessageFoldersResponse")
-    public JAXBElement<AddMessageFoldersResponse> createAddMessageFoldersResponse(AddMessageFoldersResponse value) {
-        return new JAXBElement<AddMessageFoldersResponse>(_AddMessageFoldersResponse_QNAME, AddMessageFoldersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSKeywordsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSKeywordsResponse")
-    public JAXBElement<ReadSMSKeywordsResponse> createReadSMSKeywordsResponse(ReadSMSKeywordsResponse value) {
-        return new JAXBElement<ReadSMSKeywordsResponse>(_ReadSMSKeywordsResponse_QNAME, ReadSMSKeywordsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateListsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateListsResponse")
-    public JAXBElement<UpdateListsResponse> createUpdateListsResponse(UpdateListsResponse value) {
-        return new JAXBElement<UpdateListsResponse>(_UpdateListsResponse_QNAME, UpdateListsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadAccounts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readAccounts")
-    public JAXBElement<ReadAccounts> createReadAccounts(ReadAccounts value) {
-        return new JAXBElement<ReadAccounts>(_ReadAccounts_QNAME, ReadAccounts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddContentTagsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContentTagsResponse")
-    public JAXBElement<AddContentTagsResponse> createAddContentTagsResponse(AddContentTagsResponse value) {
-        return new JAXBElement<AddContentTagsResponse>(_AddContentTagsResponse_QNAME, AddContentTagsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWorkflowsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWorkflowsResponse")
-    public JAXBElement<ReadWorkflowsResponse> createReadWorkflowsResponse(ReadWorkflowsResponse value) {
-        return new JAXBElement<ReadWorkflowsResponse>(_ReadWorkflowsResponse_QNAME, ReadWorkflowsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSKeywords }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSKeywords")
-    public JAXBElement<DeleteSMSKeywords> createDeleteSMSKeywords(DeleteSMSKeywords value) {
-        return new JAXBElement<DeleteSMSKeywords>(_DeleteSMSKeywords_QNAME, DeleteSMSKeywords.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageFoldersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageFoldersResponse")
-    public JAXBElement<DeleteMessageFoldersResponse> createDeleteMessageFoldersResponse(DeleteMessageFoldersResponse value) {
-        return new JAXBElement<DeleteMessageFoldersResponse>(_DeleteMessageFoldersResponse_QNAME, DeleteMessageFoldersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateDeliveryGroupResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateDeliveryGroupResponse")
-    public JAXBElement<AddOrUpdateDeliveryGroupResponse> createAddOrUpdateDeliveryGroupResponse(AddOrUpdateDeliveryGroupResponse value) {
-        return new JAXBElement<AddOrUpdateDeliveryGroupResponse>(_AddOrUpdateDeliveryGroupResponse_QNAME, AddOrUpdateDeliveryGroupResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContactsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContactsResponse")
-    public JAXBElement<DeleteContactsResponse> createDeleteContactsResponse(DeleteContactsResponse value) {
-        return new JAXBElement<DeleteContactsResponse>(_DeleteContactsResponse_QNAME, DeleteContactsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteAccounts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteAccounts")
-    public JAXBElement<DeleteAccounts> createDeleteAccounts(DeleteAccounts value) {
-        return new JAXBElement<DeleteAccounts>(_DeleteAccounts_QNAME, DeleteAccounts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromList }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromList")
-    public JAXBElement<RemoveFromList> createRemoveFromList(RemoveFromList value) {
-        return new JAXBElement<RemoveFromList>(_RemoveFromList_QNAME, RemoveFromList.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromListResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromListResponse")
-    public JAXBElement<RemoveFromListResponse> createRemoveFromListResponse(RemoveFromListResponse value) {
-        return new JAXBElement<RemoveFromListResponse>(_RemoveFromListResponse_QNAME, RemoveFromListResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessagesResponse")
-    public JAXBElement<AddMessagesResponse> createAddMessagesResponse(AddMessagesResponse value) {
-        return new JAXBElement<AddMessagesResponse>(_AddMessagesResponse_QNAME, AddMessagesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContentTagsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContentTagsResponse")
-    public JAXBElement<ReadContentTagsResponse> createReadContentTagsResponse(ReadContentTagsResponse value) {
-        return new JAXBElement<ReadContentTagsResponse>(_ReadContentTagsResponse_QNAME, ReadContentTagsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateLoginsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateLoginsResponse")
-    public JAXBElement<UpdateLoginsResponse> createUpdateLoginsResponse(UpdateLoginsResponse value) {
-        return new JAXBElement<UpdateLoginsResponse>(_UpdateLoginsResponse_QNAME, UpdateLoginsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateContactsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateContactsResponse")
-    public JAXBElement<AddOrUpdateContactsResponse> createAddOrUpdateContactsResponse(AddOrUpdateContactsResponse value) {
-        return new JAXBElement<AddOrUpdateContactsResponse>(_AddOrUpdateContactsResponse_QNAME, AddOrUpdateContactsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveriesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveriesResponse")
-    public JAXBElement<AddDeliveriesResponse> createAddDeliveriesResponse(AddDeliveriesResponse value) {
-        return new JAXBElement<AddDeliveriesResponse>(_AddDeliveriesResponse_QNAME, AddDeliveriesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveries }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveries")
-    public JAXBElement<AddDeliveries> createAddDeliveries(AddDeliveries value) {
-        return new JAXBElement<AddDeliveries>(_AddDeliveries_QNAME, AddDeliveries.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddContentTags }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContentTags")
-    public JAXBElement<AddContentTags> createAddContentTags(AddContentTags value) {
-        return new JAXBElement<AddContentTags>(_AddContentTags_QNAME, AddContentTags.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContacts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContacts")
-    public JAXBElement<ReadContacts> createReadContacts(ReadContacts value) {
-        return new JAXBElement<ReadContacts>(_ReadContacts_QNAME, ReadContacts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactsResponse")
-    public JAXBElement<AddContactsResponse> createAddContactsResponse(AddContactsResponse value) {
-        return new JAXBElement<AddContactsResponse>(_AddContactsResponse_QNAME, AddContactsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageFolders }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageFolders")
-    public JAXBElement<DeleteMessageFolders> createDeleteMessageFolders(DeleteMessageFolders value) {
-        return new JAXBElement<DeleteMessageFolders>(_DeleteMessageFolders_QNAME, DeleteMessageFolders.class, null, value);
-    }
-
-    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link UpdateContacts }{@code >}}
      * 
      */
@@ -3172,156 +2343,21 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadApiTokens }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessages }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readApiTokens")
-    public JAXBElement<ReadApiTokens> createReadApiTokens(ReadApiTokens value) {
-        return new JAXBElement<ReadApiTokens>(_ReadApiTokens_QNAME, ReadApiTokens.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessages")
+    public JAXBElement<ReadMessages> createReadMessages(ReadMessages value) {
+        return new JAXBElement<ReadMessages>(_ReadMessages_QNAME, ReadMessages.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessages }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateContacts }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessages")
-    public JAXBElement<UpdateMessages> createUpdateMessages(UpdateMessages value) {
-        return new JAXBElement<UpdateMessages>(_UpdateMessages_QNAME, UpdateMessages.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessagesResponse")
-    public JAXBElement<DeleteMessagesResponse> createDeleteMessagesResponse(DeleteMessagesResponse value) {
-        return new JAXBElement<DeleteMessagesResponse>(_DeleteMessagesResponse_QNAME, DeleteMessagesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadBounces }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readBounces")
-    public JAXBElement<ReadBounces> createReadBounces(ReadBounces value) {
-        return new JAXBElement<ReadBounces>(_ReadBounces_QNAME, ReadBounces.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadListsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readListsResponse")
-    public JAXBElement<ReadListsResponse> createReadListsResponse(ReadListsResponse value) {
-        return new JAXBElement<ReadListsResponse>(_ReadListsResponse_QNAME, ReadListsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSMessages }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSMessages")
-    public JAXBElement<UpdateSMSMessages> createUpdateSMSMessages(UpdateSMSMessages value) {
-        return new JAXBElement<UpdateSMSMessages>(_UpdateSMSMessages_QNAME, UpdateSMSMessages.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryGroupsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryGroupsResponse")
-    public JAXBElement<ReadDeliveryGroupsResponse> createReadDeliveryGroupsResponse(ReadDeliveryGroupsResponse value) {
-        return new JAXBElement<ReadDeliveryGroupsResponse>(_ReadDeliveryGroupsResponse_QNAME, ReadDeliveryGroupsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddToDeliveryGroupResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToDeliveryGroupResponse")
-    public JAXBElement<AddToDeliveryGroupResponse> createAddToDeliveryGroupResponse(AddToDeliveryGroupResponse value) {
-        return new JAXBElement<AddToDeliveryGroupResponse>(_AddToDeliveryGroupResponse_QNAME, AddToDeliveryGroupResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveryGroupResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveryGroupResponse")
-    public JAXBElement<UpdateDeliveryGroupResponse> createUpdateDeliveryGroupResponse(UpdateDeliveryGroupResponse value) {
-        return new JAXBElement<UpdateDeliveryGroupResponse>(_UpdateDeliveryGroupResponse_QNAME, UpdateDeliveryGroupResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateFieldsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateFieldsResponse")
-    public JAXBElement<UpdateFieldsResponse> createUpdateFieldsResponse(UpdateFieldsResponse value) {
-        return new JAXBElement<UpdateFieldsResponse>(_UpdateFieldsResponse_QNAME, UpdateFieldsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveries }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveries")
-    public JAXBElement<UpdateDeliveries> createUpdateDeliveries(UpdateDeliveries value) {
-        return new JAXBElement<UpdateDeliveries>(_UpdateDeliveries_QNAME, UpdateDeliveries.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddToSMSKeyword }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToSMSKeyword")
-    public JAXBElement<AddToSMSKeyword> createAddToSMSKeyword(AddToSMSKeyword value) {
-        return new JAXBElement<AddToSMSKeyword>(_AddToSMSKeyword_QNAME, AddToSMSKeyword.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSDeliveries }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSDeliveries")
-    public JAXBElement<AddSMSDeliveries> createAddSMSDeliveries(AddSMSDeliveries value) {
-        return new JAXBElement<AddSMSDeliveries>(_AddSMSDeliveries_QNAME, AddSMSDeliveries.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSMessagesResponse")
-    public JAXBElement<UpdateSMSMessagesResponse> createUpdateSMSMessagesResponse(UpdateSMSMessagesResponse value) {
-        return new JAXBElement<UpdateSMSMessagesResponse>(_UpdateSMSMessagesResponse_QNAME, UpdateSMSMessagesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddContacts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContacts")
-    public JAXBElement<AddContacts> createAddContacts(AddContacts value) {
-        return new JAXBElement<AddContacts>(_AddContacts_QNAME, AddContacts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddLists }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addLists")
-    public JAXBElement<AddLists> createAddLists(AddLists value) {
-        return new JAXBElement<AddLists>(_AddLists_QNAME, AddLists.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSMessagesResponse")
-    public JAXBElement<ReadSMSMessagesResponse> createReadSMSMessagesResponse(ReadSMSMessagesResponse value) {
-        return new JAXBElement<ReadSMSMessagesResponse>(_ReadSMSMessagesResponse_QNAME, ReadSMSMessagesResponse.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateContacts")
+    public JAXBElement<AddOrUpdateContacts> createAddOrUpdateContacts(AddOrUpdateContacts value) {
+        return new JAXBElement<AddOrUpdateContacts>(_AddOrUpdateContacts_QNAME, AddOrUpdateContacts.class, null, value);
     }
 
     /**
@@ -3334,435 +2370,21 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateApiTokens }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateOrders }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateApiTokens")
-    public JAXBElement<UpdateApiTokens> createUpdateApiTokens(UpdateApiTokens value) {
-        return new JAXBElement<UpdateApiTokens>(_UpdateApiTokens_QNAME, UpdateApiTokens.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateOrders")
+    public JAXBElement<AddOrUpdateOrders> createAddOrUpdateOrders(AddOrUpdateOrders value) {
+        return new JAXBElement<AddOrUpdateOrders>(_AddOrUpdateOrders_QNAME, AddOrUpdateOrders.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteLoginsResponse }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddLists }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteLoginsResponse")
-    public JAXBElement<DeleteLoginsResponse> createDeleteLoginsResponse(DeleteLoginsResponse value) {
-        return new JAXBElement<DeleteLoginsResponse>(_DeleteLoginsResponse_QNAME, DeleteLoginsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWebformsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWebformsResponse")
-    public JAXBElement<ReadWebformsResponse> createReadWebformsResponse(ReadWebformsResponse value) {
-        return new JAXBElement<ReadWebformsResponse>(_ReadWebformsResponse_QNAME, ReadWebformsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadHeaderFooters }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readHeaderFooters")
-    public JAXBElement<ReadHeaderFooters> createReadHeaderFooters(ReadHeaderFooters value) {
-        return new JAXBElement<ReadHeaderFooters>(_ReadHeaderFooters_QNAME, ReadHeaderFooters.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddConversion }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addConversion")
-    public JAXBElement<AddConversion> createAddConversion(AddConversion value) {
-        return new JAXBElement<AddConversion>(_AddConversion_QNAME, AddConversion.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveryGroup }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveryGroup")
-    public JAXBElement<AddDeliveryGroup> createAddDeliveryGroup(AddDeliveryGroup value) {
-        return new JAXBElement<AddDeliveryGroup>(_AddDeliveryGroup_QNAME, AddDeliveryGroup.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddWorkflows }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addWorkflows")
-    public JAXBElement<AddWorkflows> createAddWorkflows(AddWorkflows value) {
-        return new JAXBElement<AddWorkflows>(_AddWorkflows_QNAME, AddWorkflows.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSMessages }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSMessages")
-    public JAXBElement<AddSMSMessages> createAddSMSMessages(AddSMSMessages value) {
-        return new JAXBElement<AddSMSMessages>(_AddSMSMessages_QNAME, AddSMSMessages.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSDeliveriesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSDeliveriesResponse")
-    public JAXBElement<UpdateSMSDeliveriesResponse> createUpdateSMSDeliveriesResponse(UpdateSMSDeliveriesResponse value) {
-        return new JAXBElement<UpdateSMSDeliveriesResponse>(_UpdateSMSDeliveriesResponse_QNAME, UpdateSMSDeliveriesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddAccountsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addAccountsResponse")
-    public JAXBElement<AddAccountsResponse> createAddAccountsResponse(AddAccountsResponse value) {
-        return new JAXBElement<AddAccountsResponse>(_AddAccountsResponse_QNAME, AddAccountsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageRules }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageRules")
-    public JAXBElement<DeleteMessageRules> createDeleteMessageRules(DeleteMessageRules value) {
-        return new JAXBElement<DeleteMessageRules>(_DeleteMessageRules_QNAME, DeleteMessageRules.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateApiTokensResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateApiTokensResponse")
-    public JAXBElement<UpdateApiTokensResponse> createUpdateApiTokensResponse(UpdateApiTokensResponse value) {
-        return new JAXBElement<UpdateApiTokensResponse>(_UpdateApiTokensResponse_QNAME, UpdateApiTokensResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContacts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContacts")
-    public JAXBElement<DeleteContacts> createDeleteContacts(DeleteContacts value) {
-        return new JAXBElement<DeleteContacts>(_DeleteContacts_QNAME, DeleteContacts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactEventResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactEventResponse")
-    public JAXBElement<AddContactEventResponse> createAddContactEventResponse(AddContactEventResponse value) {
-        return new JAXBElement<AddContactEventResponse>(_AddContactEventResponse_QNAME, AddContactEventResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddToDeliveryGroup }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToDeliveryGroup")
-    public JAXBElement<AddToDeliveryGroup> createAddToDeliveryGroup(AddToDeliveryGroup value) {
-        return new JAXBElement<AddToDeliveryGroup>(_AddToDeliveryGroup_QNAME, AddToDeliveryGroup.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteHeaderFootersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteHeaderFootersResponse")
-    public JAXBElement<DeleteHeaderFootersResponse> createDeleteHeaderFootersResponse(DeleteHeaderFootersResponse value) {
-        return new JAXBElement<DeleteHeaderFootersResponse>(_DeleteHeaderFootersResponse_QNAME, DeleteHeaderFootersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFields }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFields")
-    public JAXBElement<DeleteFields> createDeleteFields(DeleteFields value) {
-        return new JAXBElement<DeleteFields>(_DeleteFields_QNAME, DeleteFields.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddUpdateOrder }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addUpdateOrder")
-    public JAXBElement<AddUpdateOrder> createAddUpdateOrder(AddUpdateOrder value) {
-        return new JAXBElement<AddUpdateOrder>(_AddUpdateOrder_QNAME, AddUpdateOrder.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateLogins }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateLogins")
-    public JAXBElement<UpdateLogins> createUpdateLogins(UpdateLogins value) {
-        return new JAXBElement<UpdateLogins>(_UpdateLogins_QNAME, UpdateLogins.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessagesResponse")
-    public JAXBElement<ReadMessagesResponse> createReadMessagesResponse(ReadMessagesResponse value) {
-        return new JAXBElement<ReadMessagesResponse>(_ReadMessagesResponse_QNAME, ReadMessagesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateOrdersResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateOrdersResponse")
-    public JAXBElement<AddOrUpdateOrdersResponse> createAddOrUpdateOrdersResponse(AddOrUpdateOrdersResponse value) {
-        return new JAXBElement<AddOrUpdateOrdersResponse>(_AddOrUpdateOrdersResponse_QNAME, AddOrUpdateOrdersResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFromDeliveryGroupResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFromDeliveryGroupResponse")
-    public JAXBElement<DeleteFromDeliveryGroupResponse> createDeleteFromDeliveryGroupResponse(DeleteFromDeliveryGroupResponse value) {
-        return new JAXBElement<DeleteFromDeliveryGroupResponse>(_DeleteFromDeliveryGroupResponse_QNAME, DeleteFromDeliveryGroupResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateDeliveryGroup }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateDeliveryGroup")
-    public JAXBElement<AddOrUpdateDeliveryGroup> createAddOrUpdateDeliveryGroup(AddOrUpdateDeliveryGroup value) {
-        return new JAXBElement<AddOrUpdateDeliveryGroup>(_AddOrUpdateDeliveryGroup_QNAME, AddOrUpdateDeliveryGroup.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddWorkflowsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addWorkflowsResponse")
-    public JAXBElement<AddWorkflowsResponse> createAddWorkflowsResponse(AddWorkflowsResponse value) {
-        return new JAXBElement<AddWorkflowsResponse>(_AddWorkflowsResponse_QNAME, AddWorkflowsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddFields }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addFields")
-    public JAXBElement<AddFields> createAddFields(AddFields value) {
-        return new JAXBElement<AddFields>(_AddFields_QNAME, AddFields.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateContactsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateContactsResponse")
-    public JAXBElement<UpdateContactsResponse> createUpdateContactsResponse(UpdateContactsResponse value) {
-        return new JAXBElement<UpdateContactsResponse>(_UpdateContactsResponse_QNAME, UpdateContactsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentInboundActivitiesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentInboundActivitiesResponse")
-    public JAXBElement<ReadRecentInboundActivitiesResponse> createReadRecentInboundActivitiesResponse(ReadRecentInboundActivitiesResponse value) {
-        return new JAXBElement<ReadRecentInboundActivitiesResponse>(_ReadRecentInboundActivitiesResponse_QNAME, ReadRecentInboundActivitiesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteWorkflows }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteWorkflows")
-    public JAXBElement<DeleteWorkflows> createDeleteWorkflows(DeleteWorkflows value) {
-        return new JAXBElement<DeleteWorkflows>(_DeleteWorkflows_QNAME, DeleteWorkflows.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWorkflows }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWorkflows")
-    public JAXBElement<ReadWorkflows> createReadWorkflows(ReadWorkflows value) {
-        return new JAXBElement<ReadWorkflows>(_ReadWorkflows_QNAME, ReadWorkflows.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSegmentsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSegmentsResponse")
-    public JAXBElement<ReadSegmentsResponse> createReadSegmentsResponse(ReadSegmentsResponse value) {
-        return new JAXBElement<ReadSegmentsResponse>(_ReadSegmentsResponse_QNAME, ReadSegmentsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentInboundActivities }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentInboundActivities")
-    public JAXBElement<ReadRecentInboundActivities> createReadRecentInboundActivities(ReadRecentInboundActivities value) {
-        return new JAXBElement<ReadRecentInboundActivities>(_ReadRecentInboundActivities_QNAME, ReadRecentInboundActivities.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSKeywordsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSKeywordsResponse")
-    public JAXBElement<DeleteSMSKeywordsResponse> createDeleteSMSKeywordsResponse(DeleteSMSKeywordsResponse value) {
-        return new JAXBElement<DeleteSMSKeywordsResponse>(_DeleteSMSKeywordsResponse_QNAME, DeleteSMSKeywordsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddLoginsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addLoginsResponse")
-    public JAXBElement<AddLoginsResponse> createAddLoginsResponse(AddLoginsResponse value) {
-        return new JAXBElement<AddLoginsResponse>(_AddLoginsResponse_QNAME, AddLoginsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContentTags }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContentTags")
-    public JAXBElement<DeleteContentTags> createDeleteContentTags(DeleteContentTags value) {
-        return new JAXBElement<DeleteContentTags>(_DeleteContentTags_QNAME, DeleteContentTags.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadUnsubscribesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readUnsubscribesResponse")
-    public JAXBElement<ReadUnsubscribesResponse> createReadUnsubscribesResponse(ReadUnsubscribesResponse value) {
-        return new JAXBElement<ReadUnsubscribesResponse>(_ReadUnsubscribesResponse_QNAME, ReadUnsubscribesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageRulesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageRulesResponse")
-    public JAXBElement<UpdateMessageRulesResponse> createUpdateMessageRulesResponse(UpdateMessageRulesResponse value) {
-        return new JAXBElement<UpdateMessageRulesResponse>(_UpdateMessageRulesResponse_QNAME, UpdateMessageRulesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSDeliveries }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSDeliveries")
-    public JAXBElement<DeleteSMSDeliveries> createDeleteSMSDeliveries(DeleteSMSDeliveries value) {
-        return new JAXBElement<DeleteSMSDeliveries>(_DeleteSMSDeliveries_QNAME, DeleteSMSDeliveries.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryGroups }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryGroups")
-    public JAXBElement<ReadDeliveryGroups> createReadDeliveryGroups(ReadDeliveryGroups value) {
-        return new JAXBElement<ReadDeliveryGroups>(_ReadDeliveryGroups_QNAME, ReadDeliveryGroups.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadBouncesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readBouncesResponse")
-    public JAXBElement<ReadBouncesResponse> createReadBouncesResponse(ReadBouncesResponse value) {
-        return new JAXBElement<ReadBouncesResponse>(_ReadBouncesResponse_QNAME, ReadBouncesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageRules }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageRules")
-    public JAXBElement<UpdateMessageRules> createUpdateMessageRules(UpdateMessageRules value) {
-        return new JAXBElement<UpdateMessageRules>(_UpdateMessageRules_QNAME, UpdateMessageRules.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ApiException }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "ApiException")
-    public JAXBElement<ApiException> createApiException(ApiException value) {
-        return new JAXBElement<ApiException>(_ApiException_QNAME, ApiException.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateAccountsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateAccountsResponse")
-    public JAXBElement<UpdateAccountsResponse> createUpdateAccountsResponse(UpdateAccountsResponse value) {
-        return new JAXBElement<UpdateAccountsResponse>(_UpdateAccountsResponse_QNAME, UpdateAccountsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadFieldsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readFieldsResponse")
-    public JAXBElement<ReadFieldsResponse> createReadFieldsResponse(ReadFieldsResponse value) {
-        return new JAXBElement<ReadFieldsResponse>(_ReadFieldsResponse_QNAME, ReadFieldsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadActivitiesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readActivitiesResponse")
-    public JAXBElement<ReadActivitiesResponse> createReadActivitiesResponse(ReadActivitiesResponse value) {
-        return new JAXBElement<ReadActivitiesResponse>(_ReadActivitiesResponse_QNAME, ReadActivitiesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromSMSKeyword }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromSMSKeyword")
-    public JAXBElement<RemoveFromSMSKeyword> createRemoveFromSMSKeyword(RemoveFromSMSKeyword value) {
-        return new JAXBElement<RemoveFromSMSKeyword>(_RemoveFromSMSKeyword_QNAME, RemoveFromSMSKeyword.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContentTagsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContentTagsResponse")
-    public JAXBElement<DeleteContentTagsResponse> createDeleteContentTagsResponse(DeleteContentTagsResponse value) {
-        return new JAXBElement<DeleteContentTagsResponse>(_DeleteContentTagsResponse_QNAME, DeleteContentTagsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadLogins }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readLogins")
-    public JAXBElement<ReadLogins> createReadLogins(ReadLogins value) {
-        return new JAXBElement<ReadLogins>(_ReadLogins_QNAME, ReadLogins.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteLogins }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteLogins")
-    public JAXBElement<DeleteLogins> createDeleteLogins(DeleteLogins value) {
-        return new JAXBElement<DeleteLogins>(_DeleteLogins_QNAME, DeleteLogins.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addLists")
+    public JAXBElement<AddLists> createAddLists(AddLists value) {
+        return new JAXBElement<AddLists>(_AddLists_QNAME, AddLists.class, null, value);
     }
 
     /**
@@ -3775,12 +2397,12 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddToList }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSMessages }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToList")
-    public JAXBElement<AddToList> createAddToList(AddToList value) {
-        return new JAXBElement<AddToList>(_AddToList_QNAME, AddToList.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSMessages")
+    public JAXBElement<AddSMSMessages> createAddSMSMessages(AddSMSMessages value) {
+        return new JAXBElement<AddSMSMessages>(_AddSMSMessages_QNAME, AddSMSMessages.class, null, value);
     }
 
     /**
@@ -3793,156 +2415,48 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteOrdersResponse }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFieldsResponse }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteOrdersResponse")
-    public JAXBElement<DeleteOrdersResponse> createDeleteOrdersResponse(DeleteOrdersResponse value) {
-        return new JAXBElement<DeleteOrdersResponse>(_DeleteOrdersResponse_QNAME, DeleteOrdersResponse.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFieldsResponse")
+    public JAXBElement<DeleteFieldsResponse> createDeleteFieldsResponse(DeleteFieldsResponse value) {
+        return new JAXBElement<DeleteFieldsResponse>(_DeleteFieldsResponse_QNAME, DeleteFieldsResponse.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link LoginResponse }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateFieldsResponse }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "loginResponse")
-    public JAXBElement<LoginResponse> createLoginResponse(LoginResponse value) {
-        return new JAXBElement<LoginResponse>(_LoginResponse_QNAME, LoginResponse.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateFieldsResponse")
+    public JAXBElement<UpdateFieldsResponse> createUpdateFieldsResponse(UpdateFieldsResponse value) {
+        return new JAXBElement<UpdateFieldsResponse>(_UpdateFieldsResponse_QNAME, UpdateFieldsResponse.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSDeliveriesResponse }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactEventResponse }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSDeliveriesResponse")
-    public JAXBElement<ReadSMSDeliveriesResponse> createReadSMSDeliveriesResponse(ReadSMSDeliveriesResponse value) {
-        return new JAXBElement<ReadSMSDeliveriesResponse>(_ReadSMSDeliveriesResponse_QNAME, ReadSMSDeliveriesResponse.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactEventResponse")
+    public JAXBElement<AddContactEventResponse> createAddContactEventResponse(AddContactEventResponse value) {
+        return new JAXBElement<AddContactEventResponse>(_AddContactEventResponse_QNAME, AddContactEventResponse.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveriesResponse }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadActivities }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveriesResponse")
-    public JAXBElement<UpdateDeliveriesResponse> createUpdateDeliveriesResponse(UpdateDeliveriesResponse value) {
-        return new JAXBElement<UpdateDeliveriesResponse>(_UpdateDeliveriesResponse_QNAME, UpdateDeliveriesResponse.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readActivities")
+    public JAXBElement<ReadActivities> createReadActivities(ReadActivities value) {
+        return new JAXBElement<ReadActivities>(_ReadActivities_QNAME, ReadActivities.class, null, value);
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateContentTags }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadConversionsResponse }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateContentTags")
-    public JAXBElement<UpdateContentTags> createUpdateContentTags(UpdateContentTags value) {
-        return new JAXBElement<UpdateContentTags>(_UpdateContentTags_QNAME, UpdateContentTags.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessagesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessagesResponse")
-    public JAXBElement<UpdateMessagesResponse> createUpdateMessagesResponse(UpdateMessagesResponse value) {
-        return new JAXBElement<UpdateMessagesResponse>(_UpdateMessagesResponse_QNAME, UpdateMessagesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFromDeliveryGroup }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFromDeliveryGroup")
-    public JAXBElement<DeleteFromDeliveryGroup> createDeleteFromDeliveryGroup(DeleteFromDeliveryGroup value) {
-        return new JAXBElement<DeleteFromDeliveryGroup>(_DeleteFromDeliveryGroup_QNAME, DeleteFromDeliveryGroup.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveriesResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveriesResponse")
-    public JAXBElement<ReadDeliveriesResponse> createReadDeliveriesResponse(ReadDeliveriesResponse value) {
-        return new JAXBElement<ReadDeliveriesResponse>(_ReadDeliveriesResponse_QNAME, ReadDeliveriesResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateWorkflows }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateWorkflows")
-    public JAXBElement<UpdateWorkflows> createUpdateWorkflows(UpdateWorkflows value) {
-        return new JAXBElement<UpdateWorkflows>(_UpdateWorkflows_QNAME, UpdateWorkflows.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSKeywordsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSKeywordsResponse")
-    public JAXBElement<AddSMSKeywordsResponse> createAddSMSKeywordsResponse(AddSMSKeywordsResponse value) {
-        return new JAXBElement<AddSMSKeywordsResponse>(_AddSMSKeywordsResponse_QNAME, AddSMSKeywordsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link AddApiTokens }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addApiTokens")
-    public JAXBElement<AddApiTokens> createAddApiTokens(AddApiTokens value) {
-        return new JAXBElement<AddApiTokens>(_AddApiTokens_QNAME, AddApiTokens.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageFolders }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageFolders")
-    public JAXBElement<ReadMessageFolders> createReadMessageFolders(ReadMessageFolders value) {
-        return new JAXBElement<ReadMessageFolders>(_ReadMessageFolders_QNAME, ReadMessageFolders.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateAccounts }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateAccounts")
-    public JAXBElement<UpdateAccounts> createUpdateAccounts(UpdateAccounts value) {
-        return new JAXBElement<UpdateAccounts>(_UpdateAccounts_QNAME, UpdateAccounts.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSDeliveries }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSDeliveries")
-    public JAXBElement<UpdateSMSDeliveries> createUpdateSMSDeliveries(UpdateSMSDeliveries value) {
-        return new JAXBElement<UpdateSMSDeliveries>(_UpdateSMSDeliveries_QNAME, UpdateSMSDeliveries.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateHeaderFooters }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateHeaderFooters")
-    public JAXBElement<UpdateHeaderFooters> createUpdateHeaderFooters(UpdateHeaderFooters value) {
-        return new JAXBElement<UpdateHeaderFooters>(_UpdateHeaderFooters_QNAME, UpdateHeaderFooters.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteAccountsResponse }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteAccountsResponse")
-    public JAXBElement<DeleteAccountsResponse> createDeleteAccountsResponse(DeleteAccountsResponse value) {
-        return new JAXBElement<DeleteAccountsResponse>(_DeleteAccountsResponse_QNAME, DeleteAccountsResponse.class, null, value);
-    }
-
-    /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteHeaderFooters }{@code >}}
-     * 
-     */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteHeaderFooters")
-    public JAXBElement<DeleteHeaderFooters> createDeleteHeaderFooters(DeleteHeaderFooters value) {
-        return new JAXBElement<DeleteHeaderFooters>(_DeleteHeaderFooters_QNAME, DeleteHeaderFooters.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readConversionsResponse")
+    public JAXBElement<ReadConversionsResponse> createReadConversionsResponse(ReadConversionsResponse value) {
+        return new JAXBElement<ReadConversionsResponse>(_ReadConversionsResponse_QNAME, ReadConversionsResponse.class, null, value);
     }
 
     /**
@@ -3955,12 +2469,75 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFieldsResponse }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageRulesResponse }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFieldsResponse")
-    public JAXBElement<DeleteFieldsResponse> createDeleteFieldsResponse(DeleteFieldsResponse value) {
-        return new JAXBElement<DeleteFieldsResponse>(_DeleteFieldsResponse_QNAME, DeleteFieldsResponse.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageRulesResponse")
+    public JAXBElement<ReadMessageRulesResponse> createReadMessageRulesResponse(ReadMessageRulesResponse value) {
+        return new JAXBElement<ReadMessageRulesResponse>(_ReadMessageRulesResponse_QNAME, ReadMessageRulesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageRules }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageRules")
+    public JAXBElement<UpdateMessageRules> createUpdateMessageRules(UpdateMessageRules value) {
+        return new JAXBElement<UpdateMessageRules>(_UpdateMessageRules_QNAME, UpdateMessageRules.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSDeliveriesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSDeliveriesResponse")
+    public JAXBElement<ReadSMSDeliveriesResponse> createReadSMSDeliveriesResponse(ReadSMSDeliveriesResponse value) {
+        return new JAXBElement<ReadSMSDeliveriesResponse>(_ReadSMSDeliveriesResponse_QNAME, ReadSMSDeliveriesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSDeliveriesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSDeliveriesResponse")
+    public JAXBElement<UpdateSMSDeliveriesResponse> createUpdateSMSDeliveriesResponse(UpdateSMSDeliveriesResponse value) {
+        return new JAXBElement<UpdateSMSDeliveriesResponse>(_UpdateSMSDeliveriesResponse_QNAME, UpdateSMSDeliveriesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContentTags }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContentTags")
+    public JAXBElement<DeleteContentTags> createDeleteContentTags(DeleteContentTags value) {
+        return new JAXBElement<DeleteContentTags>(_DeleteContentTags_QNAME, DeleteContentTags.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddAccounts }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addAccounts")
+    public JAXBElement<AddAccounts> createAddAccounts(AddAccounts value) {
+        return new JAXBElement<AddAccounts>(_AddAccounts_QNAME, AddAccounts.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSMessagesResponse")
+    public JAXBElement<UpdateSMSMessagesResponse> createUpdateSMSMessagesResponse(UpdateSMSMessagesResponse value) {
+        return new JAXBElement<UpdateSMSMessagesResponse>(_UpdateSMSMessagesResponse_QNAME, UpdateSMSMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddToSMSKeywordResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToSMSKeywordResponse")
+    public JAXBElement<AddToSMSKeywordResponse> createAddToSMSKeywordResponse(AddToSMSKeywordResponse value) {
+        return new JAXBElement<AddToSMSKeywordResponse>(_AddToSMSKeywordResponse_QNAME, AddToSMSKeywordResponse.class, null, value);
     }
 
     /**
@@ -3973,12 +2550,795 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessagesResponse")
+    public JAXBElement<ReadMessagesResponse> createReadMessagesResponse(ReadMessagesResponse value) {
+        return new JAXBElement<ReadMessagesResponse>(_ReadMessagesResponse_QNAME, ReadMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteDeliveriesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteDeliveriesResponse")
+    public JAXBElement<DeleteDeliveriesResponse> createDeleteDeliveriesResponse(DeleteDeliveriesResponse value) {
+        return new JAXBElement<DeleteDeliveriesResponse>(_DeleteDeliveriesResponse_QNAME, DeleteDeliveriesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadHeaderFootersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readHeaderFootersResponse")
+    public JAXBElement<ReadHeaderFootersResponse> createReadHeaderFootersResponse(ReadHeaderFootersResponse value) {
+        return new JAXBElement<ReadHeaderFootersResponse>(_ReadHeaderFootersResponse_QNAME, ReadHeaderFootersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSDeliveries")
+    public JAXBElement<AddSMSDeliveries> createAddSMSDeliveries(AddSMSDeliveries value) {
+        return new JAXBElement<AddSMSDeliveries>(_AddSMSDeliveries_QNAME, AddSMSDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveryGroupResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveryGroupResponse")
+    public JAXBElement<UpdateDeliveryGroupResponse> createUpdateDeliveryGroupResponse(UpdateDeliveryGroupResponse value) {
+        return new JAXBElement<UpdateDeliveryGroupResponse>(_UpdateDeliveryGroupResponse_QNAME, UpdateDeliveryGroupResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddHeaderFooters }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addHeaderFooters")
+    public JAXBElement<AddHeaderFooters> createAddHeaderFooters(AddHeaderFooters value) {
+        return new JAXBElement<AddHeaderFooters>(_AddHeaderFooters_QNAME, AddHeaderFooters.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessageRules }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessageRules")
+    public JAXBElement<AddMessageRules> createAddMessageRules(AddMessageRules value) {
+        return new JAXBElement<AddMessageRules>(_AddMessageRules_QNAME, AddMessageRules.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddToSMSKeyword }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToSMSKeyword")
+    public JAXBElement<AddToSMSKeyword> createAddToSMSKeyword(AddToSMSKeyword value) {
+        return new JAXBElement<AddToSMSKeyword>(_AddToSMSKeyword_QNAME, AddToSMSKeyword.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSKeywordsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSKeywordsResponse")
+    public JAXBElement<ReadSMSKeywordsResponse> createReadSMSKeywordsResponse(ReadSMSKeywordsResponse value) {
+        return new JAXBElement<ReadSMSKeywordsResponse>(_ReadSMSKeywordsResponse_QNAME, ReadSMSKeywordsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessagesResponse")
+    public JAXBElement<AddMessagesResponse> createAddMessagesResponse(AddMessagesResponse value) {
+        return new JAXBElement<AddMessagesResponse>(_AddMessagesResponse_QNAME, AddMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageFoldersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageFoldersResponse")
+    public JAXBElement<DeleteMessageFoldersResponse> createDeleteMessageFoldersResponse(DeleteMessageFoldersResponse value) {
+        return new JAXBElement<DeleteMessageFoldersResponse>(_DeleteMessageFoldersResponse_QNAME, DeleteMessageFoldersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFromDeliveryGroupResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFromDeliveryGroupResponse")
+    public JAXBElement<DeleteFromDeliveryGroupResponse> createDeleteFromDeliveryGroupResponse(DeleteFromDeliveryGroupResponse value) {
+        return new JAXBElement<DeleteFromDeliveryGroupResponse>(_DeleteFromDeliveryGroupResponse_QNAME, DeleteFromDeliveryGroupResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveriesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveriesResponse")
+    public JAXBElement<ReadDeliveriesResponse> createReadDeliveriesResponse(ReadDeliveriesResponse value) {
+        return new JAXBElement<ReadDeliveriesResponse>(_ReadDeliveriesResponse_QNAME, ReadDeliveriesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSKeywords }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSKeywords")
+    public JAXBElement<ReadSMSKeywords> createReadSMSKeywords(ReadSMSKeywords value) {
+        return new JAXBElement<ReadSMSKeywords>(_ReadSMSKeywords_QNAME, ReadSMSKeywords.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddFieldsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addFieldsResponse")
+    public JAXBElement<AddFieldsResponse> createAddFieldsResponse(AddFieldsResponse value) {
+        return new JAXBElement<AddFieldsResponse>(_AddFieldsResponse_QNAME, AddFieldsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddContentTags }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContentTags")
+    public JAXBElement<AddContentTags> createAddContentTags(AddContentTags value) {
+        return new JAXBElement<AddContentTags>(_AddContentTags_QNAME, AddContentTags.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageFolders }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageFolders")
+    public JAXBElement<DeleteMessageFolders> createDeleteMessageFolders(DeleteMessageFolders value) {
+        return new JAXBElement<DeleteMessageFolders>(_DeleteMessageFolders_QNAME, DeleteMessageFolders.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWorkflows }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWorkflows")
+    public JAXBElement<ReadWorkflows> createReadWorkflows(ReadWorkflows value) {
+        return new JAXBElement<ReadWorkflows>(_ReadWorkflows_QNAME, ReadWorkflows.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessages }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessages")
+    public JAXBElement<DeleteMessages> createDeleteMessages(DeleteMessages value) {
+        return new JAXBElement<DeleteMessages>(_DeleteMessages_QNAME, DeleteMessages.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadLoginsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readLoginsResponse")
+    public JAXBElement<ReadLoginsResponse> createReadLoginsResponse(ReadLoginsResponse value) {
+        return new JAXBElement<ReadLoginsResponse>(_ReadLoginsResponse_QNAME, ReadLoginsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadListsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readListsResponse")
+    public JAXBElement<ReadListsResponse> createReadListsResponse(ReadListsResponse value) {
+        return new JAXBElement<ReadListsResponse>(_ReadListsResponse_QNAME, ReadListsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateApiTokensResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateApiTokensResponse")
+    public JAXBElement<UpdateApiTokensResponse> createUpdateApiTokensResponse(UpdateApiTokensResponse value) {
+        return new JAXBElement<UpdateApiTokensResponse>(_UpdateApiTokensResponse_QNAME, UpdateApiTokensResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddContacts }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContacts")
+    public JAXBElement<AddContacts> createAddContacts(AddContacts value) {
+        return new JAXBElement<AddContacts>(_AddContacts_QNAME, AddContacts.class, null, value);
+    }
+
+    /**
      * Create an instance of {@link JAXBElement }{@code <}{@link AddMessageFolders }{@code >}}
      * 
      */
     @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessageFolders")
     public JAXBElement<AddMessageFolders> createAddMessageFolders(AddMessageFolders value) {
         return new JAXBElement<AddMessageFolders>(_AddMessageFolders_QNAME, AddMessageFolders.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadLists }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readLists")
+    public JAXBElement<ReadLists> createReadLists(ReadLists value) {
+        return new JAXBElement<ReadLists>(_ReadLists_QNAME, ReadLists.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ClearLists }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "clearLists")
+    public JAXBElement<ClearLists> createClearLists(ClearLists value) {
+        return new JAXBElement<ClearLists>(_ClearLists_QNAME, ClearLists.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageRulesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageRulesResponse")
+    public JAXBElement<DeleteMessageRulesResponse> createDeleteMessageRulesResponse(DeleteMessageRulesResponse value) {
+        return new JAXBElement<DeleteMessageRulesResponse>(_DeleteMessageRulesResponse_QNAME, DeleteMessageRulesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSegmentsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSegmentsResponse")
+    public JAXBElement<ReadSegmentsResponse> createReadSegmentsResponse(ReadSegmentsResponse value) {
+        return new JAXBElement<ReadSegmentsResponse>(_ReadSegmentsResponse_QNAME, ReadSegmentsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveriesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveriesResponse")
+    public JAXBElement<UpdateDeliveriesResponse> createUpdateDeliveriesResponse(UpdateDeliveriesResponse value) {
+        return new JAXBElement<UpdateDeliveriesResponse>(_UpdateDeliveriesResponse_QNAME, UpdateDeliveriesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteDeliveries")
+    public JAXBElement<DeleteDeliveries> createDeleteDeliveries(DeleteDeliveries value) {
+        return new JAXBElement<DeleteDeliveries>(_DeleteDeliveries_QNAME, DeleteDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateWorkflowsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateWorkflowsResponse")
+    public JAXBElement<UpdateWorkflowsResponse> createUpdateWorkflowsResponse(UpdateWorkflowsResponse value) {
+        return new JAXBElement<UpdateWorkflowsResponse>(_UpdateWorkflowsResponse_QNAME, UpdateWorkflowsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSMessagesResponse")
+    public JAXBElement<DeleteSMSMessagesResponse> createDeleteSMSMessagesResponse(DeleteSMSMessagesResponse value) {
+        return new JAXBElement<DeleteSMSMessagesResponse>(_DeleteSMSMessagesResponse_QNAME, DeleteSMSMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessageFoldersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessageFoldersResponse")
+    public JAXBElement<AddMessageFoldersResponse> createAddMessageFoldersResponse(AddMessageFoldersResponse value) {
+        return new JAXBElement<AddMessageFoldersResponse>(_AddMessageFoldersResponse_QNAME, AddMessageFoldersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateContentTags }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateContentTags")
+    public JAXBElement<UpdateContentTags> createUpdateContentTags(UpdateContentTags value) {
+        return new JAXBElement<UpdateContentTags>(_UpdateContentTags_QNAME, UpdateContentTags.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSMessagesResponse")
+    public JAXBElement<ReadSMSMessagesResponse> createReadSMSMessagesResponse(ReadSMSMessagesResponse value) {
+        return new JAXBElement<ReadSMSMessagesResponse>(_ReadSMSMessagesResponse_QNAME, ReadSMSMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteHeaderFooters }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteHeaderFooters")
+    public JAXBElement<DeleteHeaderFooters> createDeleteHeaderFooters(DeleteHeaderFooters value) {
+        return new JAXBElement<DeleteHeaderFooters>(_DeleteHeaderFooters_QNAME, DeleteHeaderFooters.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveries")
+    public JAXBElement<AddDeliveries> createAddDeliveries(AddDeliveries value) {
+        return new JAXBElement<AddDeliveries>(_AddDeliveries_QNAME, AddDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddUpdateOrderResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addUpdateOrderResponse")
+    public JAXBElement<AddUpdateOrderResponse> createAddUpdateOrderResponse(AddUpdateOrderResponse value) {
+        return new JAXBElement<AddUpdateOrderResponse>(_AddUpdateOrderResponse_QNAME, AddUpdateOrderResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ApiException }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "ApiException")
+    public JAXBElement<ApiException> createApiException(ApiException value) {
+        return new JAXBElement<ApiException>(_ApiException_QNAME, ApiException.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageRulesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageRulesResponse")
+    public JAXBElement<UpdateMessageRulesResponse> createUpdateMessageRulesResponse(UpdateMessageRulesResponse value) {
+        return new JAXBElement<UpdateMessageRulesResponse>(_UpdateMessageRulesResponse_QNAME, UpdateMessageRulesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddListsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addListsResponse")
+    public JAXBElement<AddListsResponse> createAddListsResponse(AddListsResponse value) {
+        return new JAXBElement<AddListsResponse>(_AddListsResponse_QNAME, AddListsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessages }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessages")
+    public JAXBElement<UpdateMessages> createUpdateMessages(UpdateMessages value) {
+        return new JAXBElement<UpdateMessages>(_UpdateMessages_QNAME, UpdateMessages.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddHeaderFootersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addHeaderFootersResponse")
+    public JAXBElement<AddHeaderFootersResponse> createAddHeaderFootersResponse(AddHeaderFootersResponse value) {
+        return new JAXBElement<AddHeaderFootersResponse>(_AddHeaderFootersResponse_QNAME, AddHeaderFootersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteLoginsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteLoginsResponse")
+    public JAXBElement<DeleteLoginsResponse> createDeleteLoginsResponse(DeleteLoginsResponse value) {
+        return new JAXBElement<DeleteLoginsResponse>(_DeleteLoginsResponse_QNAME, DeleteLoginsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddAccountsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addAccountsResponse")
+    public JAXBElement<AddAccountsResponse> createAddAccountsResponse(AddAccountsResponse value) {
+        return new JAXBElement<AddAccountsResponse>(_AddAccountsResponse_QNAME, AddAccountsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddConversion }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addConversion")
+    public JAXBElement<AddConversion> createAddConversion(AddConversion value) {
+        return new JAXBElement<AddConversion>(_AddConversion_QNAME, AddConversion.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageFolders }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageFolders")
+    public JAXBElement<ReadMessageFolders> createReadMessageFolders(ReadMessageFolders value) {
+        return new JAXBElement<ReadMessageFolders>(_ReadMessageFolders_QNAME, ReadMessageFolders.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessages }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessages")
+    public JAXBElement<AddMessages> createAddMessages(AddMessages value) {
+        return new JAXBElement<AddMessages>(_AddMessages_QNAME, AddMessages.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteApiTokensResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteApiTokensResponse")
+    public JAXBElement<DeleteApiTokensResponse> createDeleteApiTokensResponse(DeleteApiTokensResponse value) {
+        return new JAXBElement<DeleteApiTokensResponse>(_DeleteApiTokensResponse_QNAME, DeleteApiTokensResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadBounces }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readBounces")
+    public JAXBElement<ReadBounces> createReadBounces(ReadBounces value) {
+        return new JAXBElement<ReadBounces>(_ReadBounces_QNAME, ReadBounces.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromSMSKeyword }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromSMSKeyword")
+    public JAXBElement<RemoveFromSMSKeyword> createRemoveFromSMSKeyword(RemoveFromSMSKeyword value) {
+        return new JAXBElement<RemoveFromSMSKeyword>(_RemoveFromSMSKeyword_QNAME, RemoveFromSMSKeyword.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddLoginsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addLoginsResponse")
+    public JAXBElement<AddLoginsResponse> createAddLoginsResponse(AddLoginsResponse value) {
+        return new JAXBElement<AddLoginsResponse>(_AddLoginsResponse_QNAME, AddLoginsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddWorkflowsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addWorkflowsResponse")
+    public JAXBElement<AddWorkflowsResponse> createAddWorkflowsResponse(AddWorkflowsResponse value) {
+        return new JAXBElement<AddWorkflowsResponse>(_AddWorkflowsResponse_QNAME, AddWorkflowsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContactsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContactsResponse")
+    public JAXBElement<ReadContactsResponse> createReadContactsResponse(ReadContactsResponse value) {
+        return new JAXBElement<ReadContactsResponse>(_ReadContactsResponse_QNAME, ReadContactsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveryGroup }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveryGroup")
+    public JAXBElement<AddDeliveryGroup> createAddDeliveryGroup(AddDeliveryGroup value) {
+        return new JAXBElement<AddDeliveryGroup>(_AddDeliveryGroup_QNAME, AddDeliveryGroup.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddUpdateOrder }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addUpdateOrder")
+    public JAXBElement<AddUpdateOrder> createAddUpdateOrder(AddUpdateOrder value) {
+        return new JAXBElement<AddUpdateOrder>(_AddUpdateOrder_QNAME, AddUpdateOrder.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveriesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveriesResponse")
+    public JAXBElement<AddDeliveriesResponse> createAddDeliveriesResponse(AddDeliveriesResponse value) {
+        return new JAXBElement<AddDeliveriesResponse>(_AddDeliveriesResponse_QNAME, AddDeliveriesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddConversionResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addConversionResponse")
+    public JAXBElement<AddConversionResponse> createAddConversionResponse(AddConversionResponse value) {
+        return new JAXBElement<AddConversionResponse>(_AddConversionResponse_QNAME, AddConversionResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddDeliveryGroupResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addDeliveryGroupResponse")
+    public JAXBElement<AddDeliveryGroupResponse> createAddDeliveryGroupResponse(AddDeliveryGroupResponse value) {
+        return new JAXBElement<AddDeliveryGroupResponse>(_AddDeliveryGroupResponse_QNAME, AddDeliveryGroupResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWebforms }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWebforms")
+    public JAXBElement<ReadWebforms> createReadWebforms(ReadWebforms value) {
+        return new JAXBElement<ReadWebforms>(_ReadWebforms_QNAME, ReadWebforms.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteListsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteListsResponse")
+    public JAXBElement<DeleteListsResponse> createDeleteListsResponse(DeleteListsResponse value) {
+        return new JAXBElement<DeleteListsResponse>(_DeleteListsResponse_QNAME, DeleteListsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSMessages }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSMessages")
+    public JAXBElement<UpdateSMSMessages> createUpdateSMSMessages(UpdateSMSMessages value) {
+        return new JAXBElement<UpdateSMSMessages>(_UpdateSMSMessages_QNAME, UpdateSMSMessages.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWorkflowsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWorkflowsResponse")
+    public JAXBElement<ReadWorkflowsResponse> createReadWorkflowsResponse(ReadWorkflowsResponse value) {
+        return new JAXBElement<ReadWorkflowsResponse>(_ReadWorkflowsResponse_QNAME, ReadWorkflowsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateAccountsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateAccountsResponse")
+    public JAXBElement<UpdateAccountsResponse> createUpdateAccountsResponse(UpdateAccountsResponse value) {
+        return new JAXBElement<UpdateAccountsResponse>(_UpdateAccountsResponse_QNAME, UpdateAccountsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactsResponse")
+    public JAXBElement<AddContactsResponse> createAddContactsResponse(AddContactsResponse value) {
+        return new JAXBElement<AddContactsResponse>(_AddContactsResponse_QNAME, AddContactsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Login }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "login")
+    public JAXBElement<Login> createLogin(Login value) {
+        return new JAXBElement<Login>(_Login_QNAME, Login.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSKeywordsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSKeywordsResponse")
+    public JAXBElement<DeleteSMSKeywordsResponse> createDeleteSMSKeywordsResponse(DeleteSMSKeywordsResponse value) {
+        return new JAXBElement<DeleteSMSKeywordsResponse>(_DeleteSMSKeywordsResponse_QNAME, DeleteSMSKeywordsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateAccounts }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateAccounts")
+    public JAXBElement<UpdateAccounts> createUpdateAccounts(UpdateAccounts value) {
+        return new JAXBElement<UpdateAccounts>(_UpdateAccounts_QNAME, UpdateAccounts.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateContactsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateContactsResponse")
+    public JAXBElement<AddOrUpdateContactsResponse> createAddOrUpdateContactsResponse(AddOrUpdateContactsResponse value) {
+        return new JAXBElement<AddOrUpdateContactsResponse>(_AddOrUpdateContactsResponse_QNAME, AddOrUpdateContactsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadFields }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readFields")
+    public JAXBElement<ReadFields> createReadFields(ReadFields value) {
+        return new JAXBElement<ReadFields>(_ReadFields_QNAME, ReadFields.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSMessages }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSMessages")
+    public JAXBElement<ReadSMSMessages> createReadSMSMessages(ReadSMSMessages value) {
+        return new JAXBElement<ReadSMSMessages>(_ReadSMSMessages_QNAME, ReadSMSMessages.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSDeliveries")
+    public JAXBElement<DeleteSMSDeliveries> createDeleteSMSDeliveries(DeleteSMSDeliveries value) {
+        return new JAXBElement<DeleteSMSDeliveries>(_DeleteSMSDeliveries_QNAME, DeleteSMSDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadFieldsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readFieldsResponse")
+    public JAXBElement<ReadFieldsResponse> createReadFieldsResponse(ReadFieldsResponse value) {
+        return new JAXBElement<ReadFieldsResponse>(_ReadFieldsResponse_QNAME, ReadFieldsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteLists }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteLists")
+    public JAXBElement<DeleteLists> createDeleteLists(DeleteLists value) {
+        return new JAXBElement<DeleteLists>(_DeleteLists_QNAME, DeleteLists.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddToListResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToListResponse")
+    public JAXBElement<AddToListResponse> createAddToListResponse(AddToListResponse value) {
+        return new JAXBElement<AddToListResponse>(_AddToListResponse_QNAME, AddToListResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContentTagsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContentTagsResponse")
+    public JAXBElement<DeleteContentTagsResponse> createDeleteContentTagsResponse(DeleteContentTagsResponse value) {
+        return new JAXBElement<DeleteContentTagsResponse>(_DeleteContentTagsResponse_QNAME, DeleteContentTagsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadBouncesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readBouncesResponse")
+    public JAXBElement<ReadBouncesResponse> createReadBouncesResponse(ReadBouncesResponse value) {
+        return new JAXBElement<ReadBouncesResponse>(_ReadBouncesResponse_QNAME, ReadBouncesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateDeliveryGroupResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateDeliveryGroupResponse")
+    public JAXBElement<AddOrUpdateDeliveryGroupResponse> createAddOrUpdateDeliveryGroupResponse(AddOrUpdateDeliveryGroupResponse value) {
+        return new JAXBElement<AddOrUpdateDeliveryGroupResponse>(_AddOrUpdateDeliveryGroupResponse_QNAME, AddOrUpdateDeliveryGroupResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFields }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFields")
+    public JAXBElement<DeleteFields> createDeleteFields(DeleteFields value) {
+        return new JAXBElement<DeleteFields>(_DeleteFields_QNAME, DeleteFields.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryRecipientsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryRecipientsResponse")
+    public JAXBElement<ReadDeliveryRecipientsResponse> createReadDeliveryRecipientsResponse(ReadDeliveryRecipientsResponse value) {
+        return new JAXBElement<ReadDeliveryRecipientsResponse>(_ReadDeliveryRecipientsResponse_QNAME, ReadDeliveryRecipientsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link LoginResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "loginResponse")
+    public JAXBElement<LoginResponse> createLoginResponse(LoginResponse value) {
+        return new JAXBElement<LoginResponse>(_LoginResponse_QNAME, LoginResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadActivitiesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readActivitiesResponse")
+    public JAXBElement<ReadActivitiesResponse> createReadActivitiesResponse(ReadActivitiesResponse value) {
+        return new JAXBElement<ReadActivitiesResponse>(_ReadActivitiesResponse_QNAME, ReadActivitiesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddMessageRulesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addMessageRulesResponse")
+    public JAXBElement<AddMessageRulesResponse> createAddMessageRulesResponse(AddMessageRulesResponse value) {
+        return new JAXBElement<AddMessageRulesResponse>(_AddMessageRulesResponse_QNAME, AddMessageRulesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadConversions }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readConversions")
+    public JAXBElement<ReadConversions> createReadConversions(ReadConversions value) {
+        return new JAXBElement<ReadConversions>(_ReadConversions_QNAME, ReadConversions.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddContentTagsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContentTagsResponse")
+    public JAXBElement<AddContentTagsResponse> createAddContentTagsResponse(AddContentTagsResponse value) {
+        return new JAXBElement<AddContentTagsResponse>(_AddContentTagsResponse_QNAME, AddContentTagsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddApiTokensResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addApiTokensResponse")
+    public JAXBElement<AddApiTokensResponse> createAddApiTokensResponse(AddApiTokensResponse value) {
+        return new JAXBElement<AddApiTokensResponse>(_AddApiTokensResponse_QNAME, AddApiTokensResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteAccountsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteAccountsResponse")
+    public JAXBElement<DeleteAccountsResponse> createDeleteAccountsResponse(DeleteAccountsResponse value) {
+        return new JAXBElement<DeleteAccountsResponse>(_DeleteAccountsResponse_QNAME, DeleteAccountsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryRecipients }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryRecipients")
+    public JAXBElement<ReadDeliveryRecipients> createReadDeliveryRecipients(ReadDeliveryRecipients value) {
+        return new JAXBElement<ReadDeliveryRecipients>(_ReadDeliveryRecipients_QNAME, ReadDeliveryRecipients.class, null, value);
     }
 
     /**
@@ -3991,12 +3351,147 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveries }{@code >}}
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateOrdersResponse }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveries")
-    public JAXBElement<ReadDeliveries> createReadDeliveries(ReadDeliveries value) {
-        return new JAXBElement<ReadDeliveries>(_ReadDeliveries_QNAME, ReadDeliveries.class, null, value);
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateOrdersResponse")
+    public JAXBElement<AddOrUpdateOrdersResponse> createAddOrUpdateOrdersResponse(AddOrUpdateOrdersResponse value) {
+        return new JAXBElement<AddOrUpdateOrdersResponse>(_AddOrUpdateOrdersResponse_QNAME, AddOrUpdateOrdersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadAccountsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readAccountsResponse")
+    public JAXBElement<ReadAccountsResponse> createReadAccountsResponse(ReadAccountsResponse value) {
+        return new JAXBElement<ReadAccountsResponse>(_ReadAccountsResponse_QNAME, ReadAccountsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadLogins }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readLogins")
+    public JAXBElement<ReadLogins> createReadLogins(ReadLogins value) {
+        return new JAXBElement<ReadLogins>(_ReadLogins_QNAME, ReadLogins.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSKeywordsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSKeywordsResponse")
+    public JAXBElement<AddSMSKeywordsResponse> createAddSMSKeywordsResponse(AddSMSKeywordsResponse value) {
+        return new JAXBElement<AddSMSKeywordsResponse>(_AddSMSKeywordsResponse_QNAME, AddSMSKeywordsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveryGroup }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveryGroup")
+    public JAXBElement<UpdateDeliveryGroup> createUpdateDeliveryGroup(UpdateDeliveryGroup value) {
+        return new JAXBElement<UpdateDeliveryGroup>(_UpdateDeliveryGroup_QNAME, UpdateDeliveryGroup.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSKeywords }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSKeywords")
+    public JAXBElement<DeleteSMSKeywords> createDeleteSMSKeywords(DeleteSMSKeywords value) {
+        return new JAXBElement<DeleteSMSKeywords>(_DeleteSMSKeywords_QNAME, DeleteSMSKeywords.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSMessagesResponse")
+    public JAXBElement<AddSMSMessagesResponse> createAddSMSMessagesResponse(AddSMSMessagesResponse value) {
+        return new JAXBElement<AddSMSMessagesResponse>(_AddSMSMessagesResponse_QNAME, AddSMSMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteDeliveryGroupResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteDeliveryGroupResponse")
+    public JAXBElement<DeleteDeliveryGroupResponse> createDeleteDeliveryGroupResponse(DeleteDeliveryGroupResponse value) {
+        return new JAXBElement<DeleteDeliveryGroupResponse>(_DeleteDeliveryGroupResponse_QNAME, DeleteDeliveryGroupResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddFields }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addFields")
+    public JAXBElement<AddFields> createAddFields(AddFields value) {
+        return new JAXBElement<AddFields>(_AddFields_QNAME, AddFields.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSKeywords }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSKeywords")
+    public JAXBElement<UpdateSMSKeywords> createUpdateSMSKeywords(UpdateSMSKeywords value) {
+        return new JAXBElement<UpdateSMSKeywords>(_UpdateSMSKeywords_QNAME, UpdateSMSKeywords.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateDeliveries")
+    public JAXBElement<UpdateDeliveries> createUpdateDeliveries(UpdateDeliveries value) {
+        return new JAXBElement<UpdateDeliveries>(_UpdateDeliveries_QNAME, UpdateDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentOutboundActivitiesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentOutboundActivitiesResponse")
+    public JAXBElement<ReadRecentOutboundActivitiesResponse> createReadRecentOutboundActivitiesResponse(ReadRecentOutboundActivitiesResponse value) {
+        return new JAXBElement<ReadRecentOutboundActivitiesResponse>(_ReadRecentOutboundActivitiesResponse_QNAME, ReadRecentOutboundActivitiesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateLists }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateLists")
+    public JAXBElement<UpdateLists> createUpdateLists(UpdateLists value) {
+        return new JAXBElement<UpdateLists>(_UpdateLists_QNAME, UpdateLists.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageFoldersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageFoldersResponse")
+    public JAXBElement<ReadMessageFoldersResponse> createReadMessageFoldersResponse(ReadMessageFoldersResponse value) {
+        return new JAXBElement<ReadMessageFoldersResponse>(_ReadMessageFoldersResponse_QNAME, ReadMessageFoldersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteAccounts }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteAccounts")
+    public JAXBElement<DeleteAccounts> createDeleteAccounts(DeleteAccounts value) {
+        return new JAXBElement<DeleteAccounts>(_DeleteAccounts_QNAME, DeleteAccounts.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddToDeliveryGroup }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToDeliveryGroup")
+    public JAXBElement<AddToDeliveryGroup> createAddToDeliveryGroup(AddToDeliveryGroup value) {
+        return new JAXBElement<AddToDeliveryGroup>(_AddToDeliveryGroup_QNAME, AddToDeliveryGroup.class, null, value);
     }
 
     /**
@@ -4006,6 +3501,519 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSKeywordsResponse")
     public JAXBElement<UpdateSMSKeywordsResponse> createUpdateSMSKeywordsResponse(UpdateSMSKeywordsResponse value) {
         return new JAXBElement<UpdateSMSKeywordsResponse>(_UpdateSMSKeywordsResponse_QNAME, UpdateSMSKeywordsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddOrUpdateDeliveryGroup }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addOrUpdateDeliveryGroup")
+    public JAXBElement<AddOrUpdateDeliveryGroup> createAddOrUpdateDeliveryGroup(AddOrUpdateDeliveryGroup value) {
+        return new JAXBElement<AddOrUpdateDeliveryGroup>(_AddOrUpdateDeliveryGroup_QNAME, AddOrUpdateDeliveryGroup.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromListResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromListResponse")
+    public JAXBElement<RemoveFromListResponse> createRemoveFromListResponse(RemoveFromListResponse value) {
+        return new JAXBElement<RemoveFromListResponse>(_RemoveFromListResponse_QNAME, RemoveFromListResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateWorkflows }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateWorkflows")
+    public JAXBElement<UpdateWorkflows> createUpdateWorkflows(UpdateWorkflows value) {
+        return new JAXBElement<UpdateWorkflows>(_UpdateWorkflows_QNAME, UpdateWorkflows.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddApiTokens }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addApiTokens")
+    public JAXBElement<AddApiTokens> createAddApiTokens(AddApiTokens value) {
+        return new JAXBElement<AddApiTokens>(_AddApiTokens_QNAME, AddApiTokens.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateListsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateListsResponse")
+    public JAXBElement<UpdateListsResponse> createUpdateListsResponse(UpdateListsResponse value) {
+        return new JAXBElement<UpdateListsResponse>(_UpdateListsResponse_QNAME, UpdateListsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContactsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContactsResponse")
+    public JAXBElement<DeleteContactsResponse> createDeleteContactsResponse(DeleteContactsResponse value) {
+        return new JAXBElement<DeleteContactsResponse>(_DeleteContactsResponse_QNAME, DeleteContactsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSegments }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSegments")
+    public JAXBElement<ReadSegments> createReadSegments(ReadSegments value) {
+        return new JAXBElement<ReadSegments>(_ReadSegments_QNAME, ReadSegments.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryGroups }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryGroups")
+    public JAXBElement<ReadDeliveryGroups> createReadDeliveryGroups(ReadDeliveryGroups value) {
+        return new JAXBElement<ReadDeliveryGroups>(_ReadDeliveryGroups_QNAME, ReadDeliveryGroups.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateLoginsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateLoginsResponse")
+    public JAXBElement<UpdateLoginsResponse> createUpdateLoginsResponse(UpdateLoginsResponse value) {
+        return new JAXBElement<UpdateLoginsResponse>(_UpdateLoginsResponse_QNAME, UpdateLoginsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddLogins }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addLogins")
+    public JAXBElement<AddLogins> createAddLogins(AddLogins value) {
+        return new JAXBElement<AddLogins>(_AddLogins_QNAME, AddLogins.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContacts }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContacts")
+    public JAXBElement<ReadContacts> createReadContacts(ReadContacts value) {
+        return new JAXBElement<ReadContacts>(_ReadContacts_QNAME, ReadContacts.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateContentTagsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateContentTagsResponse")
+    public JAXBElement<UpdateContentTagsResponse> createUpdateContentTagsResponse(UpdateContentTagsResponse value) {
+        return new JAXBElement<UpdateContentTagsResponse>(_UpdateContentTagsResponse_QNAME, UpdateContentTagsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateLogins }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateLogins")
+    public JAXBElement<UpdateLogins> createUpdateLogins(UpdateLogins value) {
+        return new JAXBElement<UpdateLogins>(_UpdateLogins_QNAME, UpdateLogins.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddToDeliveryGroupResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToDeliveryGroupResponse")
+    public JAXBElement<AddToDeliveryGroupResponse> createAddToDeliveryGroupResponse(AddToDeliveryGroupResponse value) {
+        return new JAXBElement<AddToDeliveryGroupResponse>(_AddToDeliveryGroupResponse_QNAME, AddToDeliveryGroupResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentOutboundActivities }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentOutboundActivities")
+    public JAXBElement<ReadRecentOutboundActivities> createReadRecentOutboundActivities(ReadRecentOutboundActivities value) {
+        return new JAXBElement<ReadRecentOutboundActivities>(_ReadRecentOutboundActivities_QNAME, ReadRecentOutboundActivities.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactEvent }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactEvent")
+    public JAXBElement<AddContactEvent> createAddContactEvent(AddContactEvent value) {
+        return new JAXBElement<AddContactEvent>(_AddContactEvent_QNAME, AddContactEvent.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveryGroupsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveryGroupsResponse")
+    public JAXBElement<ReadDeliveryGroupsResponse> createReadDeliveryGroupsResponse(ReadDeliveryGroupsResponse value) {
+        return new JAXBElement<ReadDeliveryGroupsResponse>(_ReadDeliveryGroupsResponse_QNAME, ReadDeliveryGroupsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteWorkflowsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteWorkflowsResponse")
+    public JAXBElement<DeleteWorkflowsResponse> createDeleteWorkflowsResponse(DeleteWorkflowsResponse value) {
+        return new JAXBElement<DeleteWorkflowsResponse>(_DeleteWorkflowsResponse_QNAME, DeleteWorkflowsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadApiTokens }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readApiTokens")
+    public JAXBElement<ReadApiTokens> createReadApiTokens(ReadApiTokens value) {
+        return new JAXBElement<ReadApiTokens>(_ReadApiTokens_QNAME, ReadApiTokens.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContentTagsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContentTagsResponse")
+    public JAXBElement<ReadContentTagsResponse> createReadContentTagsResponse(ReadContentTagsResponse value) {
+        return new JAXBElement<ReadContentTagsResponse>(_ReadContentTagsResponse_QNAME, ReadContentTagsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readDeliveries")
+    public JAXBElement<ReadDeliveries> createReadDeliveries(ReadDeliveries value) {
+        return new JAXBElement<ReadDeliveries>(_ReadDeliveries_QNAME, ReadDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessagesResponse")
+    public JAXBElement<UpdateMessagesResponse> createUpdateMessagesResponse(UpdateMessagesResponse value) {
+        return new JAXBElement<UpdateMessagesResponse>(_UpdateMessagesResponse_QNAME, UpdateMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadWebformsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readWebformsResponse")
+    public JAXBElement<ReadWebformsResponse> createReadWebformsResponse(ReadWebformsResponse value) {
+        return new JAXBElement<ReadWebformsResponse>(_ReadWebformsResponse_QNAME, ReadWebformsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateHeaderFootersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateHeaderFootersResponse")
+    public JAXBElement<UpdateHeaderFootersResponse> createUpdateHeaderFootersResponse(UpdateHeaderFootersResponse value) {
+        return new JAXBElement<UpdateHeaderFootersResponse>(_UpdateHeaderFootersResponse_QNAME, UpdateHeaderFootersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateApiTokens }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateApiTokens")
+    public JAXBElement<UpdateApiTokens> createUpdateApiTokens(UpdateApiTokens value) {
+        return new JAXBElement<UpdateApiTokens>(_UpdateApiTokens_QNAME, UpdateApiTokens.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddWorkflows }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addWorkflows")
+    public JAXBElement<AddWorkflows> createAddWorkflows(AddWorkflows value) {
+        return new JAXBElement<AddWorkflows>(_AddWorkflows_QNAME, AddWorkflows.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteWorkflows }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteWorkflows")
+    public JAXBElement<DeleteWorkflows> createDeleteWorkflows(DeleteWorkflows value) {
+        return new JAXBElement<DeleteWorkflows>(_DeleteWorkflows_QNAME, DeleteWorkflows.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteContacts }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteContacts")
+    public JAXBElement<DeleteContacts> createDeleteContacts(DeleteContacts value) {
+        return new JAXBElement<DeleteContacts>(_DeleteContacts_QNAME, DeleteContacts.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteSMSDeliveriesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteSMSDeliveriesResponse")
+    public JAXBElement<DeleteSMSDeliveriesResponse> createDeleteSMSDeliveriesResponse(DeleteSMSDeliveriesResponse value) {
+        return new JAXBElement<DeleteSMSDeliveriesResponse>(_DeleteSMSDeliveriesResponse_QNAME, DeleteSMSDeliveriesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddSMSKeywords }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addSMSKeywords")
+    public JAXBElement<AddSMSKeywords> createAddSMSKeywords(AddSMSKeywords value) {
+        return new JAXBElement<AddSMSKeywords>(_AddSMSKeywords_QNAME, AddSMSKeywords.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddToList }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addToList")
+    public JAXBElement<AddToList> createAddToList(AddToList value) {
+        return new JAXBElement<AddToList>(_AddToList_QNAME, AddToList.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteHeaderFootersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteHeaderFootersResponse")
+    public JAXBElement<DeleteHeaderFootersResponse> createDeleteHeaderFootersResponse(DeleteHeaderFootersResponse value) {
+        return new JAXBElement<DeleteHeaderFootersResponse>(_DeleteHeaderFootersResponse_QNAME, DeleteHeaderFootersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentInboundActivitiesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentInboundActivitiesResponse")
+    public JAXBElement<ReadRecentInboundActivitiesResponse> createReadRecentInboundActivitiesResponse(ReadRecentInboundActivitiesResponse value) {
+        return new JAXBElement<ReadRecentInboundActivitiesResponse>(_ReadRecentInboundActivitiesResponse_QNAME, ReadRecentInboundActivitiesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateContactsResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateContactsResponse")
+    public JAXBElement<UpdateContactsResponse> createUpdateContactsResponse(UpdateContactsResponse value) {
+        return new JAXBElement<UpdateContactsResponse>(_UpdateContactsResponse_QNAME, UpdateContactsResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateSMSDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateSMSDeliveries")
+    public JAXBElement<UpdateSMSDeliveries> createUpdateSMSDeliveries(UpdateSMSDeliveries value) {
+        return new JAXBElement<UpdateSMSDeliveries>(_UpdateSMSDeliveries_QNAME, UpdateSMSDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadApiTokensResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readApiTokensResponse")
+    public JAXBElement<ReadApiTokensResponse> createReadApiTokensResponse(ReadApiTokensResponse value) {
+        return new JAXBElement<ReadApiTokensResponse>(_ReadApiTokensResponse_QNAME, ReadApiTokensResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateHeaderFooters }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateHeaderFooters")
+    public JAXBElement<UpdateHeaderFooters> createUpdateHeaderFooters(UpdateHeaderFooters value) {
+        return new JAXBElement<UpdateHeaderFooters>(_UpdateHeaderFooters_QNAME, UpdateHeaderFooters.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link AddContactsToWorkflow }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "addContactsToWorkflow")
+    public JAXBElement<AddContactsToWorkflow> createAddContactsToWorkflow(AddContactsToWorkflow value) {
+        return new JAXBElement<AddContactsToWorkflow>(_AddContactsToWorkflow_QNAME, AddContactsToWorkflow.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadUnsubscribesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readUnsubscribesResponse")
+    public JAXBElement<ReadUnsubscribesResponse> createReadUnsubscribesResponse(ReadUnsubscribesResponse value) {
+        return new JAXBElement<ReadUnsubscribesResponse>(_ReadUnsubscribesResponse_QNAME, ReadUnsubscribesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteOrdersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteOrdersResponse")
+    public JAXBElement<DeleteOrdersResponse> createDeleteOrdersResponse(DeleteOrdersResponse value) {
+        return new JAXBElement<DeleteOrdersResponse>(_DeleteOrdersResponse_QNAME, DeleteOrdersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateFields }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateFields")
+    public JAXBElement<UpdateFields> createUpdateFields(UpdateFields value) {
+        return new JAXBElement<UpdateFields>(_UpdateFields_QNAME, UpdateFields.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessagesResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessagesResponse")
+    public JAXBElement<DeleteMessagesResponse> createDeleteMessagesResponse(DeleteMessagesResponse value) {
+        return new JAXBElement<DeleteMessagesResponse>(_DeleteMessagesResponse_QNAME, DeleteMessagesResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadAccounts }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readAccounts")
+    public JAXBElement<ReadAccounts> createReadAccounts(ReadAccounts value) {
+        return new JAXBElement<ReadAccounts>(_ReadAccounts_QNAME, ReadAccounts.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromSMSKeywordResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromSMSKeywordResponse")
+    public JAXBElement<RemoveFromSMSKeywordResponse> createRemoveFromSMSKeywordResponse(RemoveFromSMSKeywordResponse value) {
+        return new JAXBElement<RemoveFromSMSKeywordResponse>(_RemoveFromSMSKeywordResponse_QNAME, RemoveFromSMSKeywordResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteLogins }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteLogins")
+    public JAXBElement<DeleteLogins> createDeleteLogins(DeleteLogins value) {
+        return new JAXBElement<DeleteLogins>(_DeleteLogins_QNAME, DeleteLogins.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadHeaderFooters }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readHeaderFooters")
+    public JAXBElement<ReadHeaderFooters> createReadHeaderFooters(ReadHeaderFooters value) {
+        return new JAXBElement<ReadHeaderFooters>(_ReadHeaderFooters_QNAME, ReadHeaderFooters.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageFolders }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageFolders")
+    public JAXBElement<UpdateMessageFolders> createUpdateMessageFolders(UpdateMessageFolders value) {
+        return new JAXBElement<UpdateMessageFolders>(_UpdateMessageFolders_QNAME, UpdateMessageFolders.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteMessageRules }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteMessageRules")
+    public JAXBElement<DeleteMessageRules> createDeleteMessageRules(DeleteMessageRules value) {
+        return new JAXBElement<DeleteMessageRules>(_DeleteMessageRules_QNAME, DeleteMessageRules.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadSMSDeliveries }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readSMSDeliveries")
+    public JAXBElement<ReadSMSDeliveries> createReadSMSDeliveries(ReadSMSDeliveries value) {
+        return new JAXBElement<ReadSMSDeliveries>(_ReadSMSDeliveries_QNAME, ReadSMSDeliveries.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadRecentInboundActivities }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readRecentInboundActivities")
+    public JAXBElement<ReadRecentInboundActivities> createReadRecentInboundActivities(ReadRecentInboundActivities value) {
+        return new JAXBElement<ReadRecentInboundActivities>(_ReadRecentInboundActivities_QNAME, ReadRecentInboundActivities.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link UpdateMessageFoldersResponse }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "updateMessageFoldersResponse")
+    public JAXBElement<UpdateMessageFoldersResponse> createUpdateMessageFoldersResponse(UpdateMessageFoldersResponse value) {
+        return new JAXBElement<UpdateMessageFoldersResponse>(_UpdateMessageFoldersResponse_QNAME, UpdateMessageFoldersResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteApiTokens }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteApiTokens")
+    public JAXBElement<DeleteApiTokens> createDeleteApiTokens(DeleteApiTokens value) {
+        return new JAXBElement<DeleteApiTokens>(_DeleteApiTokens_QNAME, DeleteApiTokens.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteOrders }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteOrders")
+    public JAXBElement<DeleteOrders> createDeleteOrders(DeleteOrders value) {
+        return new JAXBElement<DeleteOrders>(_DeleteOrders_QNAME, DeleteOrders.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadMessageRules }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readMessageRules")
+    public JAXBElement<ReadMessageRules> createReadMessageRules(ReadMessageRules value) {
+        return new JAXBElement<ReadMessageRules>(_ReadMessageRules_QNAME, ReadMessageRules.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link RemoveFromList }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "removeFromList")
+    public JAXBElement<RemoveFromList> createRemoveFromList(RemoveFromList value) {
+        return new JAXBElement<RemoveFromList>(_RemoveFromList_QNAME, RemoveFromList.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DeleteFromDeliveryGroup }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "deleteFromDeliveryGroup")
+    public JAXBElement<DeleteFromDeliveryGroup> createDeleteFromDeliveryGroup(DeleteFromDeliveryGroup value) {
+        return new JAXBElement<DeleteFromDeliveryGroup>(_DeleteFromDeliveryGroup_QNAME, DeleteFromDeliveryGroup.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link ReadContentTags }{@code >}}
+     * 
+     */
+    @XmlElementDecl(namespace = "http://api.bronto.com/v4", name = "readContentTags")
+    public JAXBElement<ReadContentTags> createReadContentTags(ReadContentTags value) {
+        return new JAXBElement<ReadContentTags>(_ReadContentTags_QNAME, ReadContentTags.class, null, value);
     }
 
 }

--- a/client/src/main/java/com/bronto/api/model/ReadFields.java
+++ b/client/src/main/java/com/bronto/api/model/ReadFields.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlType;
  *       &lt;sequence>
  *         &lt;element name="filter" type="{http://api.bronto.com/v4}fieldsFilter" minOccurs="0"/>
  *         &lt;element name="pageNumber" type="{http://www.w3.org/2001/XMLSchema}int"/>
+ *         &lt;element name="pageSize" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -29,12 +30,14 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "readFields", propOrder = {
     "filter",
-    "pageNumber"
+    "pageNumber",
+    "pageSize"
 })
 public class ReadFields {
 
     protected FieldsFilter filter;
     protected int pageNumber;
+    protected Integer pageSize;
 
     /**
      * Gets the value of the filter property.
@@ -74,6 +77,30 @@ public class ReadFields {
      */
     public void setPageNumber(int value) {
         this.pageNumber = value;
+    }
+
+    /**
+     * Gets the value of the pageSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets the value of the pageSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setPageSize(Integer value) {
+        this.pageSize = value;
     }
 
 }

--- a/client/src/main/java/com/bronto/api/model/ReadLists.java
+++ b/client/src/main/java/com/bronto/api/model/ReadLists.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlType;
  *       &lt;sequence>
  *         &lt;element name="filter" type="{http://api.bronto.com/v4}mailListFilter" minOccurs="0"/>
  *         &lt;element name="pageNumber" type="{http://www.w3.org/2001/XMLSchema}int"/>
+ *         &lt;element name="pageSize" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -29,12 +30,14 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "readLists", propOrder = {
     "filter",
-    "pageNumber"
+    "pageNumber",
+    "pageSize"
 })
 public class ReadLists {
 
     protected MailListFilter filter;
     protected int pageNumber;
+    protected Integer pageSize;
 
     /**
      * Gets the value of the filter property.
@@ -74,6 +77,30 @@ public class ReadLists {
      */
     public void setPageNumber(int value) {
         this.pageNumber = value;
+    }
+
+    /**
+     * Gets the value of the pageSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets the value of the pageSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setPageSize(Integer value) {
+        this.pageSize = value;
     }
 
 }

--- a/client/src/main/java/com/bronto/api/model/ReadMessages.java
+++ b/client/src/main/java/com/bronto/api/model/ReadMessages.java
@@ -19,6 +19,7 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="filter" type="{http://api.bronto.com/v4}messageFilter" minOccurs="0"/>
  *         &lt;element name="includeContent" type="{http://www.w3.org/2001/XMLSchema}boolean"/>
  *         &lt;element name="pageNumber" type="{http://www.w3.org/2001/XMLSchema}int"/>
+ *         &lt;element name="pageSize" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -31,13 +32,15 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(name = "readMessages", propOrder = {
     "filter",
     "includeContent",
-    "pageNumber"
+    "pageNumber",
+    "pageSize"
 })
 public class ReadMessages {
 
     protected MessageFilter filter;
     protected boolean includeContent;
     protected int pageNumber;
+    protected Integer pageSize;
 
     /**
      * Gets the value of the filter property.
@@ -93,6 +96,30 @@ public class ReadMessages {
      */
     public void setPageNumber(int value) {
         this.pageNumber = value;
+    }
+
+    /**
+     * Gets the value of the pageSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets the value of the pageSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setPageSize(Integer value) {
+        this.pageSize = value;
     }
 
 }

--- a/client/src/main/java/com/bronto/api/model/ReadSegments.java
+++ b/client/src/main/java/com/bronto/api/model/ReadSegments.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlType;
  *       &lt;sequence>
  *         &lt;element name="filter" type="{http://api.bronto.com/v4}segmentFilter" minOccurs="0"/>
  *         &lt;element name="pageNumber" type="{http://www.w3.org/2001/XMLSchema}int"/>
+ *         &lt;element name="pageSize" type="{http://www.w3.org/2001/XMLSchema}int" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -29,12 +30,14 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "readSegments", propOrder = {
     "filter",
-    "pageNumber"
+    "pageNumber",
+    "pageSize"
 })
 public class ReadSegments {
 
     protected SegmentFilter filter;
     protected int pageNumber;
+    protected Integer pageSize;
 
     /**
      * Gets the value of the filter property.
@@ -74,6 +77,30 @@ public class ReadSegments {
      */
     public void setPageNumber(int value) {
         this.pageNumber = value;
+    }
+
+    /**
+     * Gets the value of the pageSize property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * Sets the value of the pageSize property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setPageSize(Integer value) {
+        this.pageSize = value;
     }
 
 }

--- a/client/src/main/java/com/bronto/api/model/RecentActivitySearchRequest.java
+++ b/client/src/main/java/com/bronto/api/model/RecentActivitySearchRequest.java
@@ -43,8 +43,8 @@ import javax.xml.datatype.XMLGregorianCalendar;
     "readDirection"
 })
 @XmlSeeAlso({
-    RecentInboundActivitySearchRequest.class,
-    RecentOutboundActivitySearchRequest.class
+    RecentOutboundActivitySearchRequest.class,
+    RecentInboundActivitySearchRequest.class
 })
 public abstract class RecentActivitySearchRequest {
 
@@ -55,6 +55,7 @@ public abstract class RecentActivitySearchRequest {
     protected String contactId;
     protected String deliveryId;
     protected int size;
+    @XmlSchemaType(name = "string")
     protected ReadDirection readDirection;
 
     /**

--- a/client/src/main/java/com/bronto/api/model/SegmentFilter.java
+++ b/client/src/main/java/com/bronto/api/model/SegmentFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -38,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class SegmentFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/SmsDeliveryFilter.java
+++ b/client/src/main/java/com/bronto/api/model/SmsDeliveryFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -44,6 +45,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class SmsDeliveryFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/SmsKeywordFilter.java
+++ b/client/src/main/java/com/bronto/api/model/SmsKeywordFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -40,6 +41,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class SmsKeywordFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/StringValue.java
+++ b/client/src/main/java/com/bronto/api/model/StringValue.java
@@ -3,6 +3,7 @@ package com.bronto.api.model;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -33,6 +34,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class StringValue {
 
+    @XmlSchemaType(name = "string")
     protected FilterOperator operator;
     protected String value;
 

--- a/client/src/main/java/com/bronto/api/model/WebformFilter.java
+++ b/client/src/main/java/com/bronto/api/model/WebformFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -40,6 +41,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class WebformFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/client/src/main/java/com/bronto/api/model/WorkflowFilter.java
+++ b/client/src/main/java/com/bronto/api/model/WorkflowFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 
 
@@ -38,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class WorkflowFilter {
 
+    @XmlSchemaType(name = "string")
     protected FilterType type;
     @XmlElement(nillable = true)
     protected List<String> id;

--- a/sdk/src/main/java/com/bronto/api/BrontoClient.java
+++ b/sdk/src/main/java/com/bronto/api/BrontoClient.java
@@ -29,7 +29,6 @@ public class BrontoClient implements BrontoApi {
     private final BrontoSoapApiImplService apiService;
     private final BrontoClientOptions options;
     private SessionHeader header;
-    private BrontoApiObserver observer;
 
 	/**
 	 * Initializes a Bronto API client using the given API token, client
@@ -106,7 +105,6 @@ public class BrontoClient implements BrontoApi {
     }
 
     protected void setTimeouts(BrontoSoapPortType port, int adjust, BrontoClientException.Recoverable timeout) {
-        Map<String, Object> requestContext = ((BindingProvider) port).getRequestContext();
         if (timeout == null || timeout == BrontoClientException.Recoverable.READ_TIMEOUT) {
             setRequestTimeout(port, adjust);
         } else if (timeout == null || timeout == BrontoClientException.Recoverable.CONNECTION_TIMEOUT) {

--- a/sdk/src/main/java/com/bronto/api/BrontoClientAsync.java
+++ b/sdk/src/main/java/com/bronto/api/BrontoClientAsync.java
@@ -1,20 +1,13 @@
 package com.bronto.api;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import com.bronto.api.operation.AbstractAsyncObjectOperations;
 import com.bronto.api.reflect.ApiReflection;
 import com.bronto.api.request.BrontoClientRequest;
-import com.bronto.api.operation.AbstractAsyncObjectOperations;
-
-import com.bronto.api.model.BrontoSoapApiImplService;
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.SessionHeader;
-
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 public class BrontoClientAsync extends BrontoClient implements BrontoApiAsync {
     private ExecutorService executor;

--- a/sdk/src/main/java/com/bronto/api/BrontoClientException.java
+++ b/sdk/src/main/java/com/bronto/api/BrontoClientException.java
@@ -7,7 +7,10 @@ import javax.xml.ws.soap.SOAPFaultException;
 import com.bronto.api.model.ApiException_Exception;
 
 public class BrontoClientException extends RuntimeException {
-    private Recoverable recoverable;
+    
+	private static final long serialVersionUID = 3433043618935230668L;
+	
+	private Recoverable recoverable;
     private int code = 0;
 
     public static enum Recoverable {

--- a/sdk/src/main/java/com/bronto/api/BrontoWriteException.java
+++ b/sdk/src/main/java/com/bronto/api/BrontoWriteException.java
@@ -1,7 +1,10 @@
 package com.bronto.api;
 
 public class BrontoWriteException extends BrontoClientException {
-    private final WriteContext writeContext;
+    
+	private static final long serialVersionUID = -7092677683733436684L;
+	
+	private final WriteContext writeContext;
 
     public BrontoWriteException(Throwable e, WriteContext writeContext) {
         super(e);

--- a/sdk/src/main/java/com/bronto/api/CommonOperations.java
+++ b/sdk/src/main/java/com/bronto/api/CommonOperations.java
@@ -2,10 +2,8 @@ package com.bronto.api;
 
 import com.bronto.api.model.ObjectBuilder;
 import com.bronto.api.model.WriteResult;
-import com.bronto.api.request.BrontoReadRequest;
 import com.bronto.api.operation.BrontoWriteBatch;
-
-import java.util.Iterator;
+import com.bronto.api.request.BrontoReadRequest;
 
 public interface CommonOperations<O> {
     public ObjectBuilder<O> newObject();

--- a/sdk/src/main/java/com/bronto/api/ObjectOperations.java
+++ b/sdk/src/main/java/com/bronto/api/ObjectOperations.java
@@ -1,10 +1,9 @@
 package com.bronto.api;
 
-import com.bronto.api.request.BrontoReadRequest;
-import com.bronto.api.model.WriteResult;
-
 import java.util.List;
-import java.util.concurrent.Future;
+
+import com.bronto.api.model.WriteResult;
+import com.bronto.api.request.BrontoReadRequest;
 
 public interface ObjectOperations<O> extends CommonOperations<O> {
     public O get(BrontoReadRequest<O> request);
@@ -14,7 +13,10 @@ public interface ObjectOperations<O> extends CommonOperations<O> {
     public WriteResult update(List<O> objects);
     public WriteResult delete(List<O> objects);
 
-    public WriteResult add(O...objects);
-    public WriteResult update(O...objects);
-    public WriteResult delete(O...objects);
+    @SuppressWarnings("unchecked")
+	public WriteResult add(O... objects);
+    @SuppressWarnings("unchecked")
+    public WriteResult update(O... objects);
+    @SuppressWarnings("unchecked")
+    public WriteResult delete(O... objects);
 }

--- a/sdk/src/main/java/com/bronto/api/ObjectOperationsAsync.java
+++ b/sdk/src/main/java/com/bronto/api/ObjectOperationsAsync.java
@@ -14,8 +14,11 @@ public interface ObjectOperationsAsync<O> extends CommonOperations<O> {
     public Future<WriteResult> update(List<O> objects);
     public Future<WriteResult> delete(List<O> objects);
 
+    @SuppressWarnings("unchecked")
     public Future<WriteResult> add(O...objects);
+    @SuppressWarnings("unchecked")
     public Future<WriteResult> update(O...objects);
+    @SuppressWarnings("unchecked")
     public Future<WriteResult> delete(O...objects);
 
     public <V> Future<V> get(BrontoReadRequest<O> request, AsyncHandler<O, V> handler);

--- a/sdk/src/main/java/com/bronto/api/RetryLimitExceededException.java
+++ b/sdk/src/main/java/com/bronto/api/RetryLimitExceededException.java
@@ -1,7 +1,10 @@
 package com.bronto.api;
 
 public class RetryLimitExceededException extends BrontoClientException {
-    public RetryLimitExceededException(BrontoClientException e) {
+    
+	private static final long serialVersionUID = 1359096895447715669L;
+
+	public RetryLimitExceededException(BrontoClientException e) {
         super(e == null ? new RuntimeException("Exceeded retry limit") : e);
     }
 }

--- a/sdk/src/main/java/com/bronto/api/model/ObjectBuilder.java
+++ b/sdk/src/main/java/com/bronto/api/model/ObjectBuilder.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-@SuppressWarnings("unchecked")
 public class ObjectBuilder<T> {
     protected Class<T> objectClass;
     protected T object;
@@ -69,7 +68,8 @@ public class ObjectBuilder<T> {
         }
     }
 
-    public <V> ObjectBuilder<T> add(String fieldName, List<V> value) {
+    @SuppressWarnings("unchecked")
+	public <V> ObjectBuilder<T> add(String fieldName, List<V> value) {
         Field field = getField(fieldName);
         try {
             if (List.class.isAssignableFrom(field.getType())) {
@@ -90,7 +90,8 @@ public class ObjectBuilder<T> {
         }
     }
 
-    public <V> ObjectBuilder<T> add(String fieldName, V...value) {
+    @SafeVarargs
+    public final <V> ObjectBuilder<T> add(String fieldName, V... value) {
         return add(fieldName, Arrays.asList(value));
     }
 
@@ -99,6 +100,6 @@ public class ObjectBuilder<T> {
     }
 
     public static <T> ObjectBuilder<T> newObject(Class<T> objectClass) {
-        return new ObjectBuilder(objectClass);
+        return new ObjectBuilder<T>(objectClass);
     }
 }

--- a/sdk/src/main/java/com/bronto/api/model/TokenPermission.java
+++ b/sdk/src/main/java/com/bronto/api/model/TokenPermission.java
@@ -1,19 +1,13 @@
 package com.bronto.api.model;
 
 public enum TokenPermission {
-    READ(1),
-    WRITE(2),
-    READ_WRITE(3),
-    SEND(4),
-    READ_SEND(5),
-    SEND_WRITE(6),
-    READ_SEND_WRITE(7);
-
-    private int permission;
-
-    TokenPermission(int value) {
-        this.permission = value;
-    }
+    READ,
+    WRITE,
+    READ_WRITE,
+    SEND,
+    READ_SEND,
+    SEND_WRITE,
+    READ_SEND_WRITE;
 
     public boolean canRead() {
         switch (this) {

--- a/sdk/src/main/java/com/bronto/api/operation/AbstractAsyncObjectOperations.java
+++ b/sdk/src/main/java/com/bronto/api/operation/AbstractAsyncObjectOperations.java
@@ -1,27 +1,17 @@
 package com.bronto.api.operation;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
 import com.bronto.api.AsyncHandler;
 import com.bronto.api.BrontoApiAsync;
-import com.bronto.api.BrontoClientException;
 import com.bronto.api.ObjectOperationsAsync;
-import com.bronto.api.request.BrontoClientRequest;
-import com.bronto.api.request.BrontoReadRequest;
-import com.bronto.api.request.BrontoReadPager;
-import com.bronto.api.reflect.ApiReflection;
-
 import com.bronto.api.model.BrontoSoapPortType;
 import com.bronto.api.model.SessionHeader;
 import com.bronto.api.model.WriteResult;
-
-import java.lang.reflect.Method;
-
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-
-import java.util.concurrent.Future;
+import com.bronto.api.request.BrontoClientRequest;
+import com.bronto.api.request.BrontoReadRequest;
 
 public abstract class AbstractAsyncObjectOperations<O> extends AbstractCommonOperations<BrontoApiAsync, O> implements ObjectOperationsAsync<O> {
     public AbstractAsyncObjectOperations(Class<O> clazz, BrontoApiAsync client) {
@@ -90,18 +80,21 @@ public abstract class AbstractAsyncObjectOperations<O> extends AbstractCommonOpe
         return callWriteAsync("delete", objects);
     }
 
+    @SafeVarargs
     @Override
-    public Future<WriteResult> add(O...objects) {
+    public final Future<WriteResult> add(O... objects) {
         return add(Arrays.asList(objects));
     }
 
+    @SafeVarargs
     @Override
-    public Future<WriteResult> update(O...objects) {
+    public final Future<WriteResult> update(O... objects) {
         return update(Arrays.asList(objects));
     }
 
+    @SafeVarargs
     @Override
-    public Future<WriteResult> delete(O...objects) {
+    public final Future<WriteResult> delete(O... objects) {
         return delete(Arrays.asList(objects));
     }
 

--- a/sdk/src/main/java/com/bronto/api/operation/AbstractCommonOperations.java
+++ b/sdk/src/main/java/com/bronto/api/operation/AbstractCommonOperations.java
@@ -1,20 +1,14 @@
 package com.bronto.api.operation;
 
-import com.bronto.api.BrontoApi;
-import com.bronto.api.BrontoClientException;
-import com.bronto.api.CommonOperations;
-import com.bronto.api.reflect.ApiReflection;
+import java.util.Iterator;
 
+import com.bronto.api.BrontoApi;
+import com.bronto.api.CommonOperations;
 import com.bronto.api.model.ObjectBuilder;
 import com.bronto.api.model.WriteResult;
-
-import com.bronto.api.request.BrontoReadRequest;
+import com.bronto.api.reflect.ApiReflection;
 import com.bronto.api.request.BrontoReadPager;
-
-import com.bronto.api.operation.BrontoWriteBatch;
-import com.bronto.api.operation.BrontoWritePager;
-
-import java.util.Iterator;
+import com.bronto.api.request.BrontoReadRequest;
 
 public abstract class AbstractCommonOperations<C extends BrontoApi, O> implements CommonOperations<O> {
     protected final C client;
@@ -34,13 +28,12 @@ public abstract class AbstractCommonOperations<C extends BrontoApi, O> implement
         return ObjectBuilder.newObject(clazz);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Iterable<O> readAll(final BrontoReadRequest<O> request) {
         return new Iterable<O>() {
             @Override
             public Iterator<O> iterator() {
-                return new BrontoReadPager(client, request);
+                return new BrontoReadPager<O>(client, request);
             }
         };
     }
@@ -49,7 +42,7 @@ public abstract class AbstractCommonOperations<C extends BrontoApi, O> implement
         return new Iterable<WriteResult>() {
             @Override
             public Iterator<WriteResult> iterator() {
-                return new BrontoWritePager(client, reflect, batches);
+                return new BrontoWritePager<O>(client, reflect, batches);
             }
         };
     }

--- a/sdk/src/main/java/com/bronto/api/operation/AbstractObjectOperations.java
+++ b/sdk/src/main/java/com/bronto/api/operation/AbstractObjectOperations.java
@@ -1,25 +1,12 @@
 package com.bronto.api.operation;
 
-import com.bronto.api.BrontoApi;
-import com.bronto.api.BrontoClientException;
-import com.bronto.api.ObjectOperations;
-import com.bronto.api.request.BrontoClientRequest;
-import com.bronto.api.request.BrontoReadRequest;
-import com.bronto.api.request.BrontoReadPager;
-
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.SessionHeader;
-import com.bronto.api.model.WriteResult;
-
-import java.lang.reflect.Method;
-
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 
-import java.util.concurrent.Future;
+import com.bronto.api.BrontoApi;
+import com.bronto.api.ObjectOperations;
+import com.bronto.api.model.WriteResult;
+import com.bronto.api.request.BrontoReadRequest;
 
 public abstract class AbstractObjectOperations<O> extends AbstractCommonOperations<BrontoApi, O> implements ObjectOperations<O> {
 
@@ -62,18 +49,21 @@ public abstract class AbstractObjectOperations<O> extends AbstractCommonOperatio
         return callWrite("delete", objects);
     }
 
+    @SafeVarargs
     @Override
-    public WriteResult add(O...objects) {
+    public final WriteResult add(O... objects) {
         return add(Arrays.asList(objects));
     }
 
+    @SafeVarargs
     @Override
-    public WriteResult update(O...objects) {
+    public final WriteResult update(O... objects) {
         return update(Arrays.asList(objects));
     }
 
+    @SafeVarargs
     @Override
-    public WriteResult delete(O...objects) {
+    public final WriteResult delete(O... objects) {
         return delete(Arrays.asList(objects));
     }
 }

--- a/sdk/src/main/java/com/bronto/api/operation/BrontoWritePager.java
+++ b/sdk/src/main/java/com/bronto/api/operation/BrontoWritePager.java
@@ -1,18 +1,18 @@
 package com.bronto.api.operation;
 
-import com.bronto.api.BrontoApi;
-import com.bronto.api.model.WriteResult;
-import com.bronto.api.request.BrontoClientRequest;
-import com.bronto.api.reflect.ApiReflection;
-
 import java.util.Iterator;
 
-public class BrontoWritePager implements Iterator<WriteResult> {
+import com.bronto.api.BrontoApi;
+import com.bronto.api.model.WriteResult;
+import com.bronto.api.reflect.ApiReflection;
+import com.bronto.api.request.BrontoClientRequest;
+
+public class BrontoWritePager<O> implements Iterator<WriteResult> {
     private final BrontoApi client;
     private final ApiReflection reflect;
-    private final BrontoWriteBatch batches;
+    private final BrontoWriteBatch<O> batches;
 
-    public BrontoWritePager(BrontoApi client, ApiReflection reflect, BrontoWriteBatch batches) {
+    public BrontoWritePager(BrontoApi client, ApiReflection reflect, BrontoWriteBatch<O> batches) {
         this.client = client;
         this.reflect = reflect;
         this.batches = batches;

--- a/sdk/src/main/java/com/bronto/api/operation/DeliveryGroupOperationsAsync.java
+++ b/sdk/src/main/java/com/bronto/api/operation/DeliveryGroupOperationsAsync.java
@@ -1,18 +1,15 @@
 package com.bronto.api.operation;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+
 import com.bronto.api.AsyncHandler;
 import com.bronto.api.BrontoApiAsync;
-import com.bronto.api.reflect.ApiReflection;
-
-import com.bronto.api.model.AddToDeliveryGroup;
 import com.bronto.api.model.DeliveryGroupIds;
 import com.bronto.api.model.DeliveryGroupObject;
 import com.bronto.api.model.WriteResult;
-
-import java.util.Arrays;
-import java.util.List;
-
-import java.util.concurrent.Future;
+import com.bronto.api.reflect.ApiReflection;
 
 public class DeliveryGroupOperationsAsync extends AbstractAsyncObjectOperations<DeliveryGroupObject> {
     private DeliveryGroupOperations deliveryGroupOps;

--- a/sdk/src/main/java/com/bronto/api/operation/MailListOperations.java
+++ b/sdk/src/main/java/com/bronto/api/operation/MailListOperations.java
@@ -1,17 +1,15 @@
 package com.bronto.api.operation;
 
-import com.bronto.api.BrontoApi;
-import com.bronto.api.reflect.ApiReflection;
-
-import com.bronto.api.model.AddToList;
-import com.bronto.api.model.ContactObject;
-import com.bronto.api.model.RemoveFromList;
-import com.bronto.api.model.MailListObject;
-import com.bronto.api.model.WriteResult;
-
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Future;
+
+import com.bronto.api.BrontoApi;
+import com.bronto.api.model.AddToList;
+import com.bronto.api.model.ContactObject;
+import com.bronto.api.model.MailListObject;
+import com.bronto.api.model.RemoveFromList;
+import com.bronto.api.model.WriteResult;
+import com.bronto.api.reflect.ApiReflection;
 
 public class MailListOperations extends AbstractObjectOperations<MailListObject> {
 

--- a/sdk/src/main/java/com/bronto/api/operation/OrderOperations.java
+++ b/sdk/src/main/java/com/bronto/api/operation/OrderOperations.java
@@ -1,17 +1,14 @@
 package com.bronto.api.operation;
 
-import com.bronto.api.AsyncHandler;
+import java.util.Arrays;
+import java.util.List;
+
 import com.bronto.api.BrontoApi;
-
-import com.bronto.api.reflect.ApiReflection;
-
 import com.bronto.api.model.ObjectBuilder;
 import com.bronto.api.model.OrderObject;
 import com.bronto.api.model.ProductObject;
 import com.bronto.api.model.WriteResult;
-
-import java.util.Arrays;
-import java.util.List;
+import com.bronto.api.reflect.ApiReflection;
 
 public class OrderOperations extends AbstractObjectOperations<OrderObject> {
     public OrderOperations(BrontoApi client) {

--- a/sdk/src/main/java/com/bronto/api/reflect/ApiReflection.java
+++ b/sdk/src/main/java/com/bronto/api/reflect/ApiReflection.java
@@ -1,22 +1,21 @@
 package com.bronto.api.reflect;
 
+import static com.bronto.api.util.StringUtils.lowerCaseFirst;
+import static com.bronto.api.util.StringUtils.pluralize;
+import static com.bronto.api.util.StringUtils.upperCaseFirst;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.bronto.api.BrontoWriteException;
 import com.bronto.api.WriteContext;
-import com.bronto.api.request.BrontoReadRequest;
-import com.bronto.api.request.BrontoClientRequest;
-
 import com.bronto.api.model.BrontoSoapPortType;
 import com.bronto.api.model.SessionHeader;
 import com.bronto.api.model.WriteResult;
-
-import static com.bronto.api.util.StringUtils.*;
-
-import java.lang.reflect.Method;
-import java.util.Map;
-import java.util.HashMap;
-
-import java.util.Arrays;
-import java.util.List;
+import com.bronto.api.request.BrontoClientRequest;
 
 // TODO: move the special casing out of here
 // Special casing can come in the form of a translator

--- a/sdk/src/main/java/com/bronto/api/request/AbstractMessageReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/AbstractMessageReadRequest.java
@@ -1,18 +1,16 @@
 package com.bronto.api.request;
 
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.SessionHeader;
-
-import com.bronto.api.model.FilterType;
 import com.bronto.api.model.FilterOperator;
+import com.bronto.api.model.FilterType;
 import com.bronto.api.model.MessageFilter;
-import com.bronto.api.model.StringValue;
 
-import java.util.List;
-
-public abstract class AbstractMessageReadRequest<RQ, RS> extends RichReadRequest<MessageFilter, RQ, RS> {
+public abstract class AbstractMessageReadRequest<RQ, RS> extends SizedReadRequest<MessageFilter, RQ, RS> {
+    public AbstractMessageReadRequest(MessageFilter filter, RQ request, int pageNumber, int pageSize) {
+        super(filter, request, pageNumber, pageSize);
+    }
+    
     public AbstractMessageReadRequest(MessageFilter filter, RQ request, int pageNumber) {
-        super(filter, request, pageNumber);
+    	this(filter, request, pageNumber, getDefaultPageSize());
     }
 
     public abstract AbstractMessageReadRequest<RQ, RS> withIncludeContent(boolean includeContent);
@@ -20,6 +18,11 @@ public abstract class AbstractMessageReadRequest<RQ, RS> extends RichReadRequest
     public AbstractMessageReadRequest<RQ, RS> withPageNumber(int pageNumber) {
         setCurrentPage(pageNumber);
         return this;
+    }
+    
+    public AbstractMessageReadRequest<RQ, RS> withPageSize(int pageSize) {
+    	this.setPageSize(pageSize);
+    	return this;
     }
 
     public AbstractMessageReadRequest<RQ, RS> withFilterType(FilterType type) {

--- a/sdk/src/main/java/com/bronto/api/request/BrontoReadPager.java
+++ b/sdk/src/main/java/com/bronto/api/request/BrontoReadPager.java
@@ -1,18 +1,16 @@
 package com.bronto.api.request;
 
-import com.bronto.api.BrontoApi;
-import com.bronto.api.BrontoClientException;
-
 import java.util.Collections;
-import java.util.concurrent.Future;
 import java.util.Iterator;
 import java.util.List;
 
-@SuppressWarnings("unchecked")
+import com.bronto.api.BrontoApi;
+import com.bronto.api.BrontoClientException;
+
 public class BrontoReadPager<T> implements Iterator<T> {
     private Iterator<T> objects;
     private BrontoApi client;
-    private BrontoReadRequest read;
+    private BrontoReadRequest<T> read;
 
     public BrontoReadPager(BrontoApi client, BrontoReadRequest<T> read) {
         this.client = client;

--- a/sdk/src/main/java/com/bronto/api/request/ConversionReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/ConversionReadRequest.java
@@ -1,14 +1,12 @@
 package com.bronto.api.request;
 
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.SessionHeader;
+import java.util.List;
 
+import com.bronto.api.model.BrontoSoapPortType;
 import com.bronto.api.model.ConversionFilter;
 import com.bronto.api.model.ConversionObject;
 import com.bronto.api.model.ReadConversions;
-import com.bronto.api.model.StringValue;
-
-import java.util.List;
+import com.bronto.api.model.SessionHeader;
 
 public class ConversionReadRequest extends RichReadRequest<ConversionFilter, ReadConversions, ConversionObject> {
     public ConversionReadRequest(ConversionFilter filter, int pageNumber) {

--- a/sdk/src/main/java/com/bronto/api/request/DeliveryReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/DeliveryReadRequest.java
@@ -1,19 +1,17 @@
 package com.bronto.api.request;
 
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.SessionHeader;
-
-import com.bronto.api.model.DeliveryFilter;
-import com.bronto.api.model.DeliveryStatus;
-import com.bronto.api.model.DeliveryType;
-import com.bronto.api.model.DeliveryObject;
-import com.bronto.api.model.FilterType;
-import com.bronto.api.model.FilterOperator;
-import com.bronto.api.model.ReadDeliveries;
-import com.bronto.api.model.StringValue;
-
 import java.util.Date;
 import java.util.List;
+
+import com.bronto.api.model.BrontoSoapPortType;
+import com.bronto.api.model.DeliveryFilter;
+import com.bronto.api.model.DeliveryObject;
+import com.bronto.api.model.DeliveryStatus;
+import com.bronto.api.model.DeliveryType;
+import com.bronto.api.model.FilterOperator;
+import com.bronto.api.model.FilterType;
+import com.bronto.api.model.ReadDeliveries;
+import com.bronto.api.model.SessionHeader;
 
 public class DeliveryReadRequest extends RichReadRequest<DeliveryFilter, ReadDeliveries, DeliveryObject> {
     public DeliveryReadRequest(DeliveryFilter filter, int pageNumber) {

--- a/sdk/src/main/java/com/bronto/api/request/DeliveryRecipientReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/DeliveryRecipientReadRequest.java
@@ -1,16 +1,13 @@
 package com.bronto.api.request;
 
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.SessionHeader;
+import java.util.List;
 
-import com.bronto.api.model.FilterType;
-import com.bronto.api.model.FilterOperator;
+import com.bronto.api.model.BrontoSoapPortType;
 import com.bronto.api.model.DeliveryRecipientFilter;
 import com.bronto.api.model.DeliveryRecipientStatObject;
+import com.bronto.api.model.FilterType;
 import com.bronto.api.model.ReadDeliveryRecipients;
-import com.bronto.api.model.StringValue;
-
-import java.util.List;
+import com.bronto.api.model.SessionHeader;
 
 public class DeliveryRecipientReadRequest extends RichReadRequest<DeliveryRecipientFilter, ReadDeliveryRecipients, DeliveryRecipientStatObject> {
 

--- a/sdk/src/main/java/com/bronto/api/request/FieldReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/FieldReadRequest.java
@@ -1,21 +1,22 @@
 package com.bronto.api.request;
 
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.FieldType;
-import com.bronto.api.model.SessionHeader;
-
-import com.bronto.api.model.FieldsFilter;
-import com.bronto.api.model.FieldObject;
-import com.bronto.api.model.FilterType;
-import com.bronto.api.model.FilterOperator;
-import com.bronto.api.model.ReadFields;
-import com.bronto.api.model.StringValue;
-
 import java.util.List;
 
-public class FieldReadRequest extends RichReadRequest<FieldsFilter, ReadFields, FieldObject> {
+import com.bronto.api.model.BrontoSoapPortType;
+import com.bronto.api.model.FieldObject;
+import com.bronto.api.model.FieldsFilter;
+import com.bronto.api.model.FilterOperator;
+import com.bronto.api.model.FilterType;
+import com.bronto.api.model.ReadFields;
+import com.bronto.api.model.SessionHeader;
+
+public class FieldReadRequest extends SizedReadRequest<FieldsFilter, ReadFields, FieldObject> {
+    public FieldReadRequest(FieldsFilter filter, int pageNumber, int pageSize) {
+        super(filter, new ReadFields(), pageNumber, pageSize);
+    }
+    
     public FieldReadRequest(FieldsFilter filter, int pageNumber) {
-        super(filter, new ReadFields(), pageNumber);
+    	this(filter, pageNumber, getDefaultPageSize());
     }
 
     public FieldReadRequest(FieldsFilter filter) {
@@ -29,6 +30,11 @@ public class FieldReadRequest extends RichReadRequest<FieldsFilter, ReadFields, 
     public FieldReadRequest withPageNumber(int pageNumber) {
         this.setCurrentPage(pageNumber);
         return this;
+    }
+    
+    public FieldReadRequest withPageSize(int pageSize) {
+    	this.setPageSize(pageSize);
+    	return this;
     }
 
     public FieldReadRequest withId(String...ids) {
@@ -53,13 +59,16 @@ public class FieldReadRequest extends RichReadRequest<FieldsFilter, ReadFields, 
 
     @Override
     public FieldReadRequest copy() {
-        return new FieldReadRequest(getFilter(), getCurrentPage());
+        return new FieldReadRequest(getFilter(), getCurrentPage(), getPageSize());
     }
 
     @Override
     public List<FieldObject> invoke(BrontoSoapPortType service, SessionHeader header) throws Exception {
         request.setFilter(getFilter());
         request.setPageNumber(getCurrentPage());
+        if (!isDefaultPageSize()) {
+        	request.setPageSize(getPageSize());
+        }
         return service.readFields(request, header).getReturn();
     }
 }

--- a/sdk/src/main/java/com/bronto/api/request/MailListReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/MailListReadRequest.java
@@ -12,9 +12,13 @@ import com.bronto.api.model.StringValue;
 
 import java.util.List;
 
-public class MailListReadRequest extends RichReadRequest<MailListFilter, ReadLists, MailListObject> {
+public class MailListReadRequest extends SizedReadRequest<MailListFilter, ReadLists, MailListObject> {
+    public MailListReadRequest(MailListFilter filter, int pageNumber, int pageSize) {
+        super(filter, new ReadLists(), pageNumber, pageSize);
+    }
+    
     public MailListReadRequest(MailListFilter filter, int pageNumber) {
-        super(filter, new ReadLists(), pageNumber);
+    	this(filter, pageNumber, getDefaultPageSize());
     }
 
     public MailListReadRequest(MailListFilter filter) {
@@ -28,6 +32,11 @@ public class MailListReadRequest extends RichReadRequest<MailListFilter, ReadLis
     public MailListReadRequest withPageNumber(int pageNumber) {
         this.setCurrentPage(pageNumber);
         return this;
+    }
+    
+    public MailListReadRequest withPageSize(int pageSize) {
+    	this.setPageSize(pageSize);
+    	return this;
     }
 
     public MailListReadRequest withName(StringValue...names) {
@@ -57,13 +66,16 @@ public class MailListReadRequest extends RichReadRequest<MailListFilter, ReadLis
 
     @Override
     public MailListReadRequest copy() {
-        return new MailListReadRequest(getFilter(), getCurrentPage());
+        return new MailListReadRequest(getFilter(), getCurrentPage(), getPageSize());
     }
 
     @Override
     public List<MailListObject> invoke(BrontoSoapPortType service, SessionHeader header) throws Exception {
         request.setFilter(getFilter());
         request.setPageNumber(getCurrentPage());
+        if (!isDefaultPageSize()) {
+        	request.setPageSize(getPageSize());
+        }
         return service.readLists(request, header).getReturn();
     }
 }

--- a/sdk/src/main/java/com/bronto/api/request/MessageReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/MessageReadRequest.java
@@ -10,9 +10,13 @@ import com.bronto.api.model.ReadMessages;
 import java.util.List;
 
 public class MessageReadRequest extends AbstractMessageReadRequest<ReadMessages, MessageObject> {
-    public MessageReadRequest(MessageFilter filter, int pageNumber) {
-        super(filter, new ReadMessages(), pageNumber);
+    public MessageReadRequest(MessageFilter filter, int pageNumber, int pageSize) {
+        super(filter, new ReadMessages(), pageNumber, pageSize);
         withIncludeContent(false);
+    }
+    
+    public MessageReadRequest(MessageFilter filter, int pageNumber) {
+    	this(filter, pageNumber, getDefaultPageSize());
     }
 
     public MessageReadRequest(MessageFilter filter) {
@@ -31,7 +35,7 @@ public class MessageReadRequest extends AbstractMessageReadRequest<ReadMessages,
 
     @Override
     public MessageReadRequest copy() {
-        return new MessageReadRequest(getFilter(), getCurrentPage())
+        return new MessageReadRequest(getFilter(), getCurrentPage(), getPageSize())
             .withIncludeContent(request.isIncludeContent());
     }
 
@@ -39,6 +43,9 @@ public class MessageReadRequest extends AbstractMessageReadRequest<ReadMessages,
     public List<MessageObject> invoke(BrontoSoapPortType service, SessionHeader header) throws Exception {
         request.setFilter(getFilter());
         request.setPageNumber(getCurrentPage());
+        if (!isDefaultPageSize()) {
+        	request.setPageSize(getPageSize());
+        }
         return service.readMessages(request, header).getReturn();
     }
 }

--- a/sdk/src/main/java/com/bronto/api/request/RecentActivitiesReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/RecentActivitiesReadRequest.java
@@ -1,16 +1,16 @@
 package com.bronto.api.request;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import com.bronto.api.model.ActivityPageSize;
 import com.bronto.api.model.BrontoSoapPortType;
 import com.bronto.api.model.ReadDirection;
 import com.bronto.api.model.RecentActivityObject;
-import com.bronto.api.model.RecentActivityType;
 import com.bronto.api.model.RecentActivitySearchRequest;
+import com.bronto.api.model.RecentActivityType;
 import com.bronto.api.model.SessionHeader;
 import com.bronto.api.util.ConversionUtils;
 
@@ -20,52 +20,52 @@ public abstract class RecentActivitiesReadRequest<T extends RecentActivitySearch
         super(filter, request, pageNumber);
     }
 
-    public RecentActivitiesReadRequest withPageNumber(int pageNumber) {
+    public RecentActivitiesReadRequest<T, RQ> withPageNumber(int pageNumber) {
         this.setCurrentPage(pageNumber);
         return this;
     }
 
-    public RecentActivitiesReadRequest withPageSize(ActivityPageSize size) {
+    public RecentActivitiesReadRequest<T, RQ> withPageSize(ActivityPageSize size) {
         getFilter().setSize(size.getSize());
         return this;
     }
 
-    public RecentActivitiesReadRequest withContactId(String contactId) {
+    public RecentActivitiesReadRequest<T, RQ> withContactId(String contactId) {
         getFilter().setContactId(contactId);
         return this;
     }
 
-    public RecentActivitiesReadRequest withDeliveryId(String deliveryId) {
+    public RecentActivitiesReadRequest<T, RQ> withDeliveryId(String deliveryId) {
         getFilter().setDeliveryId(deliveryId);
         return this;
     }
 
-    public RecentActivitiesReadRequest withStart(Date start) {
+    public RecentActivitiesReadRequest<T, RQ> withStart(Date start) {
         return withStart(ConversionUtils.toXMLCalendar(start));
     }
 
-    public RecentActivitiesReadRequest withStart(XMLGregorianCalendar start) {
+    public RecentActivitiesReadRequest<T, RQ> withStart(XMLGregorianCalendar start) {
         getFilter().setStart(start);
         return this;
     }
 
-    public RecentActivitiesReadRequest withEnd(Date end) {
+    public RecentActivitiesReadRequest<T, RQ> withEnd(Date end) {
         return withEnd(ConversionUtils.toXMLCalendar(end));
     }
 
-    public RecentActivitiesReadRequest withEnd(XMLGregorianCalendar end) {
+    public RecentActivitiesReadRequest<T, RQ> withEnd(XMLGregorianCalendar end) {
         getFilter().setEnd(end);
         return this;
     }
 
-    public RecentActivitiesReadRequest withReadDirection(ReadDirection direction) {
+    public RecentActivitiesReadRequest<T, RQ> withReadDirection(ReadDirection direction) {
         getFilter().setReadDirection(direction);
         return this;
     }
 
     protected abstract List<RecentActivityObject> invokeSpecificRead(BrontoSoapPortType service, SessionHeader header) throws Exception;
 
-    public RecentActivitiesReadRequest withTypes(RecentActivityType...types) {
+    public RecentActivitiesReadRequest<T, RQ> withTypes(RecentActivityType...types) {
         String[] values = new String[types.length];
         for (int i = 0; i < types.length; i++) {
             values[i] = types[i].getApiValue();
@@ -73,7 +73,7 @@ public abstract class RecentActivitiesReadRequest<T extends RecentActivitySearch
         return withTypes(values);
     }
 
-    public abstract RecentActivitiesReadRequest withTypes(String...types);
+    public abstract RecentActivitiesReadRequest<T, RQ> withTypes(String...types);
 
     @Override
     public List<RecentActivityObject> invoke(BrontoSoapPortType service, SessionHeader header) throws Exception {

--- a/sdk/src/main/java/com/bronto/api/request/RecentInboundActivitiesReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/RecentInboundActivitiesReadRequest.java
@@ -22,7 +22,7 @@ public class RecentInboundActivitiesReadRequest extends RecentActivitiesReadRequ
     }
 
     @Override
-    public RecentActivitiesReadRequest withTypes(String...types) {
+    public RecentActivitiesReadRequest<RecentInboundActivitySearchRequest, ReadRecentInboundActivities> withTypes(String...types) {
         setStrings(getFilter().getTypes(), types);
         return this;
     }

--- a/sdk/src/main/java/com/bronto/api/request/RecentOutboundActivitiesReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/RecentOutboundActivitiesReadRequest.java
@@ -22,7 +22,7 @@ public class RecentOutboundActivitiesReadRequest extends RecentActivitiesReadReq
     }
 
     @Override
-    public RecentActivitiesReadRequest withTypes(String...types) {
+    public RecentActivitiesReadRequest<RecentOutboundActivitySearchRequest, ReadRecentOutboundActivities> withTypes(String...types) {
         setStrings(getFilter().getTypes(), types);
         return this;
     }

--- a/sdk/src/main/java/com/bronto/api/request/SegmentReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/SegmentReadRequest.java
@@ -12,9 +12,13 @@ import com.bronto.api.model.StringValue;
 
 import java.util.List;
 
-public class SegmentReadRequest extends RichReadRequest<SegmentFilter, ReadSegments, SegmentObject> {
+public class SegmentReadRequest extends SizedReadRequest<SegmentFilter, ReadSegments, SegmentObject> {
+    public SegmentReadRequest(SegmentFilter filter, int pageNumber, int pageSize) {
+        super(filter, new ReadSegments(), pageNumber, pageSize);
+    }
+    
     public SegmentReadRequest(SegmentFilter filter, int pageNumber) {
-        super(filter, new ReadSegments(), pageNumber);
+    	this(filter, pageNumber, getDefaultPageSize());
     }
 
     public SegmentReadRequest(SegmentFilter filter) {
@@ -28,6 +32,11 @@ public class SegmentReadRequest extends RichReadRequest<SegmentFilter, ReadSegme
     public SegmentReadRequest withPageNumber(int pageNumber) {
         this.setCurrentPage(pageNumber);
         return this;
+    }
+    
+    public SegmentReadRequest withPageSize(int pageSize) {
+    	this.setPageSize(pageSize);
+    	return this;
     }
 
     public SegmentReadRequest withName(StringValue...names) {
@@ -57,13 +66,16 @@ public class SegmentReadRequest extends RichReadRequest<SegmentFilter, ReadSegme
 
     @Override
     public SegmentReadRequest copy() {
-        return new SegmentReadRequest(getFilter(), getCurrentPage());
+        return new SegmentReadRequest(getFilter(), getCurrentPage(), getPageSize());
     }
 
     @Override
     public List<SegmentObject> invoke(BrontoSoapPortType service, SessionHeader header) throws Exception {
         request.setFilter(getFilter());
         request.setPageNumber(getCurrentPage());
+        if (!isDefaultPageSize()) {
+        	request.setPageSize(getPageSize());
+        }
         return service.readSegments(request, header).getReturn();
     }
 }

--- a/sdk/src/main/java/com/bronto/api/request/SizedReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/SizedReadRequest.java
@@ -1,0 +1,44 @@
+package com.bronto.api.request;
+
+public abstract class SizedReadRequest<RF, RQ, RS> extends RichReadRequest<RF, RQ, RS> {
+
+	private static final int DEFAULT_PAGE_SIZE = 0;
+	private static final int MINIMUM_PAGE_SIZE = 10;
+	private static final int MAXIMUM_PAGE_SIZE = 5000;
+	
+	private int pageSize = getDefaultPageSize();
+	
+	public SizedReadRequest(RF filter, RQ request, int pageNumber, int pageSize) {
+		super(filter, request, pageNumber);
+		setPageSize(pageSize);
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize <= 0 ? getDefaultPageSize() : clampPageSize(pageSize);
+	}
+	
+	public boolean isDefaultPageSize() {
+		return getPageSize() == getDefaultPageSize();
+	}
+	
+	public static int getDefaultPageSize() {
+		return DEFAULT_PAGE_SIZE;
+	}
+	
+	public static int getMinimumPageSize() {
+		return MINIMUM_PAGE_SIZE;
+	}
+	
+	public static int getMaximumPageSize() {
+		return MAXIMUM_PAGE_SIZE;
+	}
+	
+	private static int clampPageSize(int pageSize) {
+		return Math.max(getMinimumPageSize(), Math.min(getMaximumPageSize(), pageSize));
+	}
+	
+}

--- a/sdk/src/main/java/com/bronto/api/request/SmsDeliveryReadRequest.java
+++ b/sdk/src/main/java/com/bronto/api/request/SmsDeliveryReadRequest.java
@@ -1,17 +1,14 @@
 package com.bronto.api.request;
 
-import com.bronto.api.model.BrontoSoapPortType;
-import com.bronto.api.model.SessionHeader;
-
-import com.bronto.api.model.FilterType;
-import com.bronto.api.model.FilterOperator;
-import com.bronto.api.model.SmsDeliveryFilter;
-import com.bronto.api.model.SmsDeliveryObject;
-import com.bronto.api.model.ReadSMSDeliveries;
-import com.bronto.api.model.StringValue;
-
 import java.util.Date;
 import java.util.List;
+
+import com.bronto.api.model.BrontoSoapPortType;
+import com.bronto.api.model.FilterType;
+import com.bronto.api.model.ReadSMSDeliveries;
+import com.bronto.api.model.SessionHeader;
+import com.bronto.api.model.SmsDeliveryFilter;
+import com.bronto.api.model.SmsDeliveryObject;
 
 public class SmsDeliveryReadRequest extends RichReadRequest<SmsDeliveryFilter, ReadSMSDeliveries, SmsDeliveryObject> {
     public SmsDeliveryReadRequest(SmsDeliveryFilter filter, int pageNumber) {


### PR DESCRIPTION
This includes support for pageSize in read requests for fields, messages, lists, and segments.

Aside from re-generating the WSDL, the biggest changes are the addition of the SizedReadRequest abstract class which the following classes take advantage of: FieldReadRequest, MessageReadRequest, SegmentReadRequest, and MailListReadRequest. The re-generated WSDL also adds support for delivery product objects for including SKUs from the new product service.

The behavior is that if no page size is set, or a page size is set to 0 or anything below that, we won't send the page size constraint to Bronto and it will default to the current behavior, which is to allow Bronto to decide the page size.

If a page size is set to a value outside of the minimum (10) and maximum bounds (5000), the value is clamped to the nearest boundary. We do this to stop the user of the SDK from passing in a value that will cause a page size exception to occur and these are documented boundaries. We could remove this auto-clamping if we want and allow the developer to simply hit the exception.

The design of the SizedReadRequest is purposeful in case these minimum and maximum boundaries end up differing for the various endpoints in the future. This allows the user of the SDK to code to the boundaries without hardcoding numbers that may eventually be invalid as well as allows the subclasses of SizedReadRequest to define their own boundaries. The clamping helps aids this as well in case the user does hard code a page size value that becomes invalid.