### PR TITLE
JAVA-24: Adding some exposure to this batch writing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .project
 .settings
 .classpath
+*.swp

--- a/sdk/src/main/java/com/bronto/api/BrontoWriteExceptionTransform.java
+++ b/sdk/src/main/java/com/bronto/api/BrontoWriteExceptionTransform.java
@@ -1,0 +1,5 @@
+package com.bronto.api;
+
+public interface BrontoWriteExceptionTransform<O> {
+    public O transform(BrontoWriteException exception);
+}

--- a/sdk/src/main/java/com/bronto/api/CommonOperations.java
+++ b/sdk/src/main/java/com/bronto/api/CommonOperations.java
@@ -9,4 +9,5 @@ public interface CommonOperations<O> {
     public ObjectBuilder<O> newObject();
     public Iterable<O> readAll(BrontoReadRequest<O> request);
     public Iterable<WriteResult> writeAll(BrontoWriteBatch<O> batch);
+    public Iterable<WriteResult> writeAll(BrontoWriteBatch<O> batch, BrontoWriteExceptionTransform<WriteResult> handle);
 }

--- a/sdk/src/main/java/com/bronto/api/operation/AbstractCommonOperations.java
+++ b/sdk/src/main/java/com/bronto/api/operation/AbstractCommonOperations.java
@@ -3,6 +3,7 @@ package com.bronto.api.operation;
 import java.util.Iterator;
 
 import com.bronto.api.BrontoApi;
+import com.bronto.api.BrontoWriteExceptionTransform;
 import com.bronto.api.CommonOperations;
 import com.bronto.api.model.ObjectBuilder;
 import com.bronto.api.model.WriteResult;
@@ -38,11 +39,22 @@ public abstract class AbstractCommonOperations<C extends BrontoApi, O> implement
         };
     }
 
+    @Override
     public Iterable<WriteResult> writeAll(final BrontoWriteBatch<O> batches) {
         return new Iterable<WriteResult>() {
             @Override
             public Iterator<WriteResult> iterator() {
                 return new BrontoWritePager<O>(client, reflect, batches);
+            }
+        };
+    }
+
+    @Override
+    public Iterable<WriteResult> writeAll(final BrontoWriteBatch<O> batches, final BrontoWriteExceptionTransform<WriteResult> handle) {
+        return new Iterable<WriteResult>() {
+            @Override
+            public Iterator<WriteResult> iterator() {
+                return new BrontoWritePager<O>(client, reflect, batches, handle);
             }
         };
     }

--- a/sdk/src/main/java/com/bronto/api/operation/AbstractCommonOperations.java
+++ b/sdk/src/main/java/com/bronto/api/operation/AbstractCommonOperations.java
@@ -41,12 +41,7 @@ public abstract class AbstractCommonOperations<C extends BrontoApi, O> implement
 
     @Override
     public Iterable<WriteResult> writeAll(final BrontoWriteBatch<O> batches) {
-        return new Iterable<WriteResult>() {
-            @Override
-            public Iterator<WriteResult> iterator() {
-                return new BrontoWritePager<O>(client, reflect, batches);
-            }
-        };
+        return writeAll(batches, new DefaultWriteExceptionTransform<O>(client, reflect, batches));
     }
 
     @Override

--- a/sdk/src/main/java/com/bronto/api/operation/BrontoWriteBatch.java
+++ b/sdk/src/main/java/com/bronto/api/operation/BrontoWriteBatch.java
@@ -9,6 +9,7 @@ public class BrontoWriteBatch<O> implements Iterator<List<O>> {
     private final int batchSize;
     private final String methodName;
     private final Iterator<O> objects;
+    private List<O> currentBatch = Collections.emptyList();
     private int currentPage = 0;
 
     public BrontoWriteBatch(String methodName, int batchSize, Iterable<O> objects) {
@@ -29,6 +30,14 @@ public class BrontoWriteBatch<O> implements Iterator<List<O>> {
         return currentPage;
     }
 
+    public long getStartingPageIndex() {
+        return getCurrentPage() * getBatchSize();
+    }
+
+    public List<O> getCurrentBatch() {
+        return currentBatch;
+    }
+
     @Override
     public boolean hasNext() {
         return objects.hasNext();
@@ -43,7 +52,8 @@ public class BrontoWriteBatch<O> implements Iterator<List<O>> {
             pulledObjects.add(objects.next());
             pulledBatch++;
         }
-        return Collections.unmodifiableList(pulledObjects);
+        currentBatch = Collections.unmodifiableList(pulledObjects);
+        return currentBatch;
     }
 
     @Override

--- a/sdk/src/main/java/com/bronto/api/operation/BrontoWritePager.java
+++ b/sdk/src/main/java/com/bronto/api/operation/BrontoWritePager.java
@@ -1,13 +1,10 @@
 package com.bronto.api.operation;
 
 import java.util.Iterator;
-import java.util.List;
 
 import com.bronto.api.BrontoApi;
-import com.bronto.api.BrontoClientException.Recoverable;
 import com.bronto.api.BrontoWriteException;
 import com.bronto.api.BrontoWriteExceptionTransform;
-import com.bronto.api.model.ResultItem;
 import com.bronto.api.model.WriteResult;
 import com.bronto.api.reflect.ApiReflection;
 import com.bronto.api.request.BrontoClientRequest;
@@ -25,45 +22,16 @@ public class BrontoWritePager<O> implements Iterator<WriteResult> {
         this.handle = handle;
     }
 
-
     public BrontoWritePager(BrontoApi client, ApiReflection reflect, BrontoWriteBatch<O> batches) {
-        this(client, reflect, batches, new BrontoWriteExceptionTransform<WriteResult>() {
-            @Override
-            public WriteResult transform(BrontoWriteException bwe) {
-                WriteResult result = new WriteResult();
-                List<O> batch = batches.getCurrentBatch();
-                long startingIndex = batches.getStartingPageIndex();
-                int errorIndex = 0;
-                if (bwe.getRecoverable() == Recoverable.INVALID_REQUEST && batch.size() > 1) {
-                    BrontoWriteBatch<O> child = new BrontoWriteBatch<O>(batches.getMethod(), 1, batch);
-                    BrontoWritePager<O> pager = new BrontoWritePager<O>(client, reflect, child, this);
-                    while (pager.hasNext()) {
-                        ResultItem item = pager.next().getResults().get(0);
-                        if (item.isIsError()) {
-                            item.setId(Long.toString(startingIndex));
-                            result.getErrors().add(errorIndex);
-                        }
-                        result.getResults().add(item);
-                        startingIndex++;
-                        errorIndex++;
-                    }
-                } else {
-                    for (O object : batches.getCurrentBatch()) {
-                        ResultItem item = new ResultItem();
-                        item.setId(Long.toString(startingIndex));
-                        item.setIsNew(false);
-                        item.setIsError(true);
-                        item.setErrorCode(bwe.getCode());
-                        item.setErrorString(bwe.getMessage());
-                        result.getResults().add(item);
-                        result.getErrors().add(errorIndex);
-                        startingIndex++;
-                        errorIndex++;
-                    }
-                }
-                return result;
-            }
-        });
+        this(client, reflect, batches, new DefaultWriteExceptionTransform<O>(client, reflect, batches));
+    }
+
+    public BrontoApi getClient() {
+        return client;
+    }
+
+    public ApiReflection getReflect() {
+        return reflect;
     }
 
     public BrontoWriteBatch<O> getBatches() {

--- a/sdk/src/main/java/com/bronto/api/operation/BrontoWritePager.java
+++ b/sdk/src/main/java/com/bronto/api/operation/BrontoWritePager.java
@@ -3,6 +3,9 @@ package com.bronto.api.operation;
 import java.util.Iterator;
 
 import com.bronto.api.BrontoApi;
+import com.bronto.api.BrontoWriteException;
+import com.bronto.api.BrontoWriteExceptionTransform;
+import com.bronto.api.model.ResultItem;
 import com.bronto.api.model.WriteResult;
 import com.bronto.api.reflect.ApiReflection;
 import com.bronto.api.request.BrontoClientRequest;
@@ -11,11 +14,36 @@ public class BrontoWritePager<O> implements Iterator<WriteResult> {
     private final BrontoApi client;
     private final ApiReflection reflect;
     private final BrontoWriteBatch<O> batches;
+    private final BrontoWriteExceptionTransform<WriteResult> handle;
 
-    public BrontoWritePager(BrontoApi client, ApiReflection reflect, BrontoWriteBatch<O> batches) {
+    public BrontoWritePager(BrontoApi client, ApiReflection reflect, BrontoWriteBatch<O> batches, BrontoWriteExceptionTransform<WriteResult> handle) {
         this.client = client;
         this.reflect = reflect;
         this.batches = batches;
+        this.handle = handle;
+    }
+
+
+    public BrontoWritePager(BrontoApi client, ApiReflection reflect, BrontoWriteBatch<O> batches) {
+        this(client, reflect, batches, new BrontoWriteExceptionTransform<WriteResult>() {
+            @Override
+            public WriteResult transform(BrontoWriteException bwe) {
+                WriteResult result = new WriteResult();
+                for (O object : batches.getCurrentBatch()) {
+                    ResultItem item = new ResultItem();
+                    item.setId("-1");
+                    item.setIsNew(false);
+                    item.setIsError(true);
+                    item.setErrorCode(bwe.getCode());
+                    item.setErrorString(bwe.getMessage());
+                }
+                return result;
+            }
+        });
+    }
+
+    public BrontoWriteBatch<O> getBatches() {
+        return batches;
     }
 
     @Override
@@ -28,7 +56,11 @@ public class BrontoWritePager<O> implements Iterator<WriteResult> {
         String methodName = batches.getMethod();
         final Object call = reflect.fillMethodCall(methodName, batches.next());
         BrontoClientRequest<WriteResult> request = reflect.createMethodRequest(methodName, call);
-        return client.invoke(request);
+        try {
+            return client.invoke(request);
+        } catch (BrontoWriteException bwe) {
+            return handle.transform(bwe);
+        }
     }
 
     @Override

--- a/sdk/src/main/java/com/bronto/api/operation/DefaultWriteExceptionTransform.java
+++ b/sdk/src/main/java/com/bronto/api/operation/DefaultWriteExceptionTransform.java
@@ -1,0 +1,63 @@
+package com.bronto.api.operation;
+
+import java.util.List;
+
+import com.bronto.api.BrontoApi;
+import com.bronto.api.BrontoWriteException;
+import com.bronto.api.BrontoWriteExceptionTransform;
+import com.bronto.api.BrontoClientException.Recoverable;
+import com.bronto.api.model.ResultItem;
+import com.bronto.api.model.WriteResult;
+import com.bronto.api.reflect.ApiReflection;
+
+public class DefaultWriteExceptionTransform<O> implements BrontoWriteExceptionTransform<WriteResult> {
+    private final BrontoWriteBatch<O> batches;
+    private final BrontoApi client;
+    private final ApiReflection reflect;
+
+    public DefaultWriteExceptionTransform(BrontoApi client, ApiReflection reflect, BrontoWriteBatch<O> batches) {
+        this.client = client;
+        this.reflect = reflect;
+        this.batches = batches;
+    }
+
+    public DefaultWriteExceptionTransform(BrontoWritePager<O> pager) {
+        this(pager.getClient(), pager.getReflect(), pager.getBatches());
+    }
+
+    @Override
+    public WriteResult transform(BrontoWriteException bwe) {
+        WriteResult result = new WriteResult();
+        List<O> batch = batches.getCurrentBatch();
+        long startingIndex = batches.getStartingPageIndex();
+        int errorIndex = 0;
+        if (bwe.getRecoverable() == Recoverable.INVALID_REQUEST && batch.size() > 1) {
+            BrontoWriteBatch<O> child = new BrontoWriteBatch<O>(batches.getMethod(), 1, batch);
+            BrontoWritePager<O> pager = new BrontoWritePager<O>(client, reflect, child, this);
+            while (pager.hasNext()) {
+                ResultItem item = pager.next().getResults().get(0);
+                if (item.isIsError()) {
+                    item.setId(Long.toString(startingIndex));
+                    result.getErrors().add(errorIndex);
+                }
+                result.getResults().add(item);
+                startingIndex++;
+                errorIndex++;
+            }
+        } else {
+            for (O object : batches.getCurrentBatch()) {
+                ResultItem item = new ResultItem();
+                item.setId(Long.toString(startingIndex));
+                item.setIsNew(false);
+                item.setIsError(true);
+                item.setErrorCode(bwe.getCode());
+                item.setErrorString(bwe.getMessage());
+                result.getResults().add(item);
+                result.getErrors().add(errorIndex);
+                startingIndex++;
+                errorIndex++;
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
I've added some exposure to the batch writing going on here. This allows control over the batch process without having to do silly things, ie:

``` java
// BrontoApi client
// ContactOperations contactOps
Iterator<ContactObject> contacts = new TransformIterator<ContactObject, Event>(events.iterator()) {
    @Override
    public ContactObject transform(Event event) {
        return event.getContact();
    }
};
BrontoWriteBatch<ContactObject> batches = new BrontoWriteBatch<>("addOrUpdate", 100, TransformIterator.makeIterable(contacts));
for (WriteResult result : contactOps.writeAll(batches)) {
   // Do the work with a result
}
```